### PR TITLE
Making compiler output more clean on terminal

### DIFF
--- a/tasks.json
+++ b/tasks.json
@@ -19,7 +19,8 @@
       "isBackground": false,
       "presentation": {
         "reveal": "silent",
-        "panel": "dedicated"
+        "panel": "dedicated",
+        "clear": true
       },
       "problemMatcher": "$pawncc"
     }


### PR DESCRIPTION
# **It solves two aesthetic problems.**

### 1. Its cleaner when compiles since it hides the compilation command:

**Before**:

![image](https://github.com/user-attachments/assets/2c7a39bb-78c7-4ea4-9006-a3518f98e79d)

**After**:

![image](https://github.com/user-attachments/assets/7b737de0-e488-4895-b857-995562d58fa8)

### 2. It looks better to recompile without close the terminal from the last compile

**Before**:

![image](https://github.com/user-attachments/assets/768579b7-da07-4e33-a461-e3525e2ac2f8)

**After**:

![image](https://github.com/user-attachments/assets/3aa32dd8-131f-4e6c-bd96-b24c057f1a2b)



