### PR TITLE
Add dialog and menu preview tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pawn-development",
   "displayName": "Pawn Development Tool",
   "description": "Pawn development tool for open.mp and SA:MP",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "publisher": "openmp",
   "engines": {
     "vscode": "^1.30.0"
@@ -48,7 +48,11 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "test": "npm run compile && node ./node_modules/vscode/bin/test",
-    "publish": "vsce publish minor"
+    "publish": "vsce publish minor",
+    "lint": "eslint src --ext ts",
+    "lint:fix": "eslint src --ext ts --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\""
   },
   "dependencies": {
     "@types/vscode": "^1.70.0",
@@ -62,6 +66,7 @@
     "@typescript-eslint/eslint-plugin": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.1",
     "eslint": "^8.22.0",
+    "prettier": "^3.7.4",
     "typescript": "^4.7.4"
   },
   "contributes": {
@@ -185,6 +190,14 @@
       {
         "command": "pawn-development.reloadDefs",
         "title": "Pawn Development: reload definitions"
+      },
+      {
+        "command": "pawn-development.previewDialog",
+        "title": "Pawn Development: Preview SA-MP Dialog"
+      },
+      {
+        "command": "pawn-development.previewMenu",
+        "title": "Pawn Development: Preview SA-MP Menu"
       }
     ],
     "menus": {

--- a/src/client/buildTask.ts
+++ b/src/client/buildTask.ts
@@ -38,7 +38,7 @@ const BuildTaskHandler = async function () {
     },
     (error: Error) => {
       console.error(error);
-    }
+    },
   );
 };
 

--- a/src/client/commonFunc.ts
+++ b/src/client/commonFunc.ts
@@ -2,23 +2,22 @@ import * as vscode from "vscode";
 import { client } from "./extension";
 
 export const initSnippetCollector = async (reset = false) => {
-  const filesPwn = await vscode.workspace.findFiles("**/*.pwn");
-  for (const key in filesPwn) {
-    const element = filesPwn[key];
-    (await vscode.workspace.openTextDocument(element)).getText();
-  }
+  try {
+    const files = await vscode.workspace.findFiles("**/*.{pwn,pawn,inc}", "**/node_modules/**", 500);
 
-  const filesPawn = await vscode.workspace.findFiles("**/*.pawn");
-  for (const key in filesPawn) {
-    const element = filesPawn[key];
-    (await vscode.workspace.openTextDocument(element)).getText();
-  }
+    for (const file of files) {
+      try {
+        const doc = await vscode.workspace.openTextDocument(file);
+        doc.getText();
+      } catch {
+        // Skip files that can't be opened (e.g., permission issues, network errors)
+      }
+    }
 
-  const filesInc = await vscode.workspace.findFiles("**/*.inc");
-  for (const key in filesInc) {
-    const element = filesInc[key];
-    (await vscode.workspace.openTextDocument(element)).getText();
+    if (client !== undefined && reset) {
+      client.sendNotification("revalidateAllOpenedDocuments");
+    }
+  } catch (error) {
+    console.error("Error initializing snippet collector:", error);
   }
-
-  if (client !== undefined && reset) client.sendNotification("revalidateAllOpenedDocuments");
 };

--- a/src/client/dialog/codeLensProvider.ts
+++ b/src/client/dialog/codeLensProvider.ts
@@ -1,0 +1,42 @@
+import * as vscode from "vscode";
+import { parseDialogs } from "./parser";
+import { getDialogStyleName } from "./types";
+
+export class DialogCodeLensProvider implements vscode.CodeLensProvider {
+  private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+  public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+
+  constructor() {
+    // Refresh CodeLenses when document changes
+    vscode.workspace.onDidChangeTextDocument(() => {
+      this._onDidChangeCodeLenses.fire();
+    });
+  }
+
+  public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+    const codeLenses: vscode.CodeLens[] = [];
+    const dialogs = parseDialogs(document);
+
+    for (const dialog of dialogs) {
+      const codeLens = new vscode.CodeLens(dialog.range, {
+        title: `$(eye) Preview Dialog (${getDialogStyleName(dialog.style)})`,
+        command: "pawn-development.previewDialog",
+        arguments: [dialog],
+      });
+      codeLenses.push(codeLens);
+    }
+
+    return codeLenses;
+  }
+
+  public resolveCodeLens(codeLens: vscode.CodeLens): vscode.CodeLens {
+    return codeLens;
+  }
+
+  /**
+   * Trigger a refresh of the CodeLenses
+   */
+  public refresh(): void {
+    this._onDidChangeCodeLenses.fire();
+  }
+}

--- a/src/client/dialog/parser.ts
+++ b/src/client/dialog/parser.ts
@@ -1,0 +1,1008 @@
+import * as vscode from "vscode";
+import { SAMPDialog, DialogStyle, ColorSegment, DialogListItem, DialogResponseHandler } from "./types";
+
+/**
+ * External dialog library function mappings
+ * Maps function names to their dialog styles and parameter positions
+ */
+interface ExternalDialogPattern {
+  name: string;
+  minArgs: number;
+  maxArgs?: number;
+  style: DialogStyle | "dynamic"; // 'dynamic' means style is a parameter
+  styleParamIndex?: number; // Index of style parameter (0-based)
+  captionParamIndex: number;
+  infoParamIndex: number;
+  button1ParamIndex: number;
+  button2ParamIndex: number;
+  dialogIdPrefix: string;
+}
+
+const nativeDialogFunctionNames = ["ShowPlayerDialog", "ShowPlayerDialog_s", "MDialogFix_ShowPlayerDialog", "MDialog_ShowPlayerDialog"];
+
+const sampAsyncDialogPatterns: ExternalDialogPattern[] = [
+  {
+    name: "ShowAsyncDialog",
+    minArgs: 6,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "AsyncDialog",
+  },
+  // ShowAsyncDialog_s (same structure)
+  {
+    name: "ShowAsyncDialog_s",
+    minArgs: 6,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "AsyncDialog_s",
+  },
+  {
+    name: "ShowAsyncNumberInputDialog",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "NumberInput",
+  },
+  {
+    name: "ShowAsyncFloatInputDialog",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "FloatInput",
+  },
+  {
+    name: "ShowAsyncStringInputDialog",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "StringInput",
+  },
+  {
+    name: "ShowAsyncPasswordDialog",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.PASSWORD,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "Password",
+  },
+  {
+    name: "ShowAsyncConfirmationDialog",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.MSGBOX,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "Confirmation",
+  },
+  {
+    name: "ShowAsyncConfirmationDialog",
+    minArgs: 4,
+    maxArgs: 4,
+    style: DialogStyle.MSGBOX,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: -1,
+    dialogIdPrefix: "Confirmation",
+  },
+  {
+    name: "ShowAsyncListitemTextDialog",
+    minArgs: 6,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "ListitemText",
+  },
+  {
+    name: "ShowAsyncListitemIndexDialog",
+    minArgs: 6,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "ListitemIndex",
+  },
+  {
+    name: "ShowAsyncEntityIndexDialog",
+    minArgs: 6,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "EntityIndex",
+  },
+];
+
+const tdialogsPatterns: ExternalDialogPattern[] = [
+  {
+    name: "ShowAsyncNumberInputDialog",
+    minArgs: 6,
+    maxArgs: 6,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "NumberInput",
+  },
+  {
+    name: "ShowAsyncNumberInputDialog_s",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "NumberInput_s",
+  },
+  {
+    name: "ShowAsyncFloatInputDialog",
+    minArgs: 6,
+    maxArgs: 6,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "FloatInput",
+  },
+  {
+    name: "ShowAsyncFloatInputDialog_s",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "FloatInput_s",
+  },
+  {
+    name: "ShowAsyncStringInputDialog",
+    minArgs: 6,
+    maxArgs: 6,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "StringInput",
+  },
+  {
+    name: "ShowAsyncStringInputDialog_s",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.INPUT,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "StringInput_s",
+  },
+  {
+    name: "ShowAsyncPasswordDialog",
+    minArgs: 6,
+    maxArgs: 6,
+    style: DialogStyle.PASSWORD,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "Password",
+  },
+  {
+    name: "ShowAsyncPasswordDialog_s",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.PASSWORD,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "Password_s",
+  },
+  {
+    name: "ShowAsyncConfirmationDialog_s",
+    minArgs: 5,
+    maxArgs: 5,
+    style: DialogStyle.MSGBOX,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: 4,
+    dialogIdPrefix: "Confirmation_s",
+  },
+  {
+    name: "ShowAsyncConfirmationDialog_s",
+    minArgs: 4,
+    maxArgs: 4,
+    style: DialogStyle.MSGBOX,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: -1,
+    dialogIdPrefix: "Confirmation_s",
+  },
+  {
+    name: "ShowAsyncListitemTextDialog_s",
+    minArgs: 6,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "ListitemText_s",
+  },
+  {
+    name: "ShowAsyncListitemIndexDialog_s",
+    minArgs: 6,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "ListitemIndex_s",
+  },
+  {
+    name: "ShowAsyncEntityIndexDialog_s",
+    minArgs: 6,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "EntityIndex_s",
+  },
+  {
+    name: "ShowAsyncPaginatedDialog",
+    minArgs: 6,
+    maxArgs: 8,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 3,
+    infoParamIndex: 6,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "Paginated",
+  },
+];
+
+const easyDialogPatterns: ExternalDialogPattern[] = [
+  {
+    name: "Dialog_Open",
+    minArgs: 7,
+    style: "dynamic",
+    styleParamIndex: 2,
+    captionParamIndex: 3,
+    infoParamIndex: 4,
+    button1ParamIndex: 5,
+    button2ParamIndex: 6,
+    dialogIdPrefix: "Dialog_Open",
+  },
+  {
+    name: "Dialog_Show",
+    minArgs: 7,
+    style: "dynamic",
+    styleParamIndex: 2,
+    captionParamIndex: 3,
+    infoParamIndex: 4,
+    button1ParamIndex: 5,
+    button2ParamIndex: 6,
+    dialogIdPrefix: "Dialog_Show",
+  },
+];
+
+const yDialogPatterns: ExternalDialogPattern[] = [
+  {
+    name: "Dialog_Show",
+    minArgs: 5,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "Dialog_Show",
+  },
+  {
+    name: "Dialog_ShowCallback",
+    minArgs: 6,
+    maxArgs: 7,
+    style: "dynamic",
+    styleParamIndex: 2,
+    captionParamIndex: 3,
+    infoParamIndex: 4,
+    button1ParamIndex: 5,
+    button2ParamIndex: 6,
+    dialogIdPrefix: "Dialog_ShowCallback",
+  },
+  {
+    name: "Dialog_ShowCallbackData",
+    minArgs: 6,
+    maxArgs: 7,
+    style: "dynamic",
+    styleParamIndex: 2,
+    captionParamIndex: 3,
+    infoParamIndex: 4,
+    button1ParamIndex: 5,
+    button2ParamIndex: 6,
+    dialogIdPrefix: "Dialog_ShowCallbackData",
+  },
+];
+
+const mdialogPatterns: ExternalDialogPattern[] = [
+  {
+    name: "Dialog_Message",
+    minArgs: 4,
+    style: DialogStyle.MSGBOX,
+    captionParamIndex: 1,
+    infoParamIndex: 2,
+    button1ParamIndex: 3,
+    button2ParamIndex: -1,
+    dialogIdPrefix: "Dialog_Message",
+  },
+  {
+    name: "Dialog_MessageEx",
+    minArgs: 6,
+    style: DialogStyle.MSGBOX,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "Dialog_MessageEx",
+  },
+];
+
+const ppDialogsPatterns: ExternalDialogPattern[] = [
+  {
+    name: "ShowPlayerAsyncDialog",
+    minArgs: 5,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "ShowPlayerAsyncDialog",
+  },
+  {
+    name: "ShowPlayerAsyncDialogStr",
+    minArgs: 5,
+    maxArgs: 6,
+    style: "dynamic",
+    styleParamIndex: 1,
+    captionParamIndex: 2,
+    infoParamIndex: 3,
+    button1ParamIndex: 4,
+    button2ParamIndex: 5,
+    dialogIdPrefix: "ShowPlayerAsyncDialogStr",
+  },
+  {
+    name: "ShowPlayerDialogStr",
+    minArgs: 6,
+    maxArgs: 7,
+    style: "dynamic",
+    styleParamIndex: 2,
+    captionParamIndex: 3,
+    infoParamIndex: 4,
+    button1ParamIndex: 5,
+    button2ParamIndex: 6,
+    dialogIdPrefix: "ShowPlayerDialogStr",
+  },
+];
+
+const tdwDialogPatterns: ExternalDialogPattern[] = [
+  {
+    name: "OpenDialog",
+    minArgs: 7,
+    maxArgs: 7,
+    style: "dynamic",
+    styleParamIndex: 2,
+    captionParamIndex: 3,
+    infoParamIndex: 4,
+    button1ParamIndex: 5,
+    button2ParamIndex: 6,
+    dialogIdPrefix: "OpenDialog",
+  },
+];
+
+const externalDialogPatterns: ExternalDialogPattern[] = [
+  ...sampAsyncDialogPatterns,
+  ...tdialogsPatterns,
+  ...easyDialogPatterns,
+  ...yDialogPatterns,
+  ...mdialogPatterns,
+  ...ppDialogsPatterns,
+  ...tdwDialogPatterns,
+];
+
+/**
+ * Parse ShowPlayerDialog calls from a document
+ */
+export function parseDialogs(document: vscode.TextDocument): SAMPDialog[] {
+  const text = document.getText();
+  const dialogs: SAMPDialog[] = [];
+
+  for (const name of nativeDialogFunctionNames) {
+    for (const call of findFunctionCalls(text, name)) {
+      if (call.args.length < 7) continue;
+
+      const dialogId = call.args[1].trim();
+      const styleArg = call.args[2].trim();
+      const style = parseDialogStyle(styleArg);
+      const formattedText = resolveFormattedDialogText(text, call.args.slice(3, 7), call.args.slice(7), call.startIndex);
+
+      dialogs.push({
+        dialogId,
+        style,
+        caption: formattedText[0],
+        info: formattedText[1],
+        button1: formattedText[2],
+        button2: formattedText[3],
+        range: new vscode.Range(document.positionAt(call.startIndex), document.positionAt(call.endIndex + 1)),
+        documentUri: document.uri.toString(),
+        rawText: call.rawText,
+      });
+    }
+  }
+
+  // Parse external dialog library functions
+  const patternsByName = new Map<string, ExternalDialogPattern[]>();
+  for (const extPattern of externalDialogPatterns) {
+    const list = patternsByName.get(extPattern.name) || [];
+    list.push(extPattern);
+    patternsByName.set(extPattern.name, list);
+  }
+
+  for (const [name, patterns] of patternsByName.entries()) {
+    const calls = findFunctionCalls(text, name);
+    for (const call of calls) {
+      const pattern = patterns.find((p) => {
+        if (call.args.length < p.minArgs) return false;
+        if (p.maxArgs !== undefined && call.args.length > p.maxArgs) return false;
+        return true;
+      });
+      if (!pattern) continue;
+
+      let style: DialogStyle;
+      if (pattern.style === "dynamic" && pattern.styleParamIndex !== undefined) {
+        style = parseDialogStyle(call.args[pattern.styleParamIndex] || "");
+      } else {
+        style = pattern.style as DialogStyle;
+      }
+
+      const infoArg =
+        pattern.name === "ShowAsyncPaginatedDialog"
+          ? getPaginatedDialogInfoArgument(text, call.args[pattern.infoParamIndex] || '""', call.startIndex)
+          : call.args[pattern.infoParamIndex] || '""';
+      const formattedText = resolveFormattedDialogText(
+        text,
+        [
+          call.args[pattern.captionParamIndex] || '""',
+          infoArg,
+          call.args[pattern.button1ParamIndex] || '""',
+          pattern.button2ParamIndex >= 0 ? call.args[pattern.button2ParamIndex] || '""' : '""',
+        ],
+        [],
+        call.startIndex
+      );
+
+      dialogs.push({
+        dialogId: `[${pattern.dialogIdPrefix}]`,
+        style,
+        caption: formattedText[0],
+        info: formattedText[1],
+        button1: formattedText[2],
+        button2: pattern.button2ParamIndex >= 0 ? formattedText[3] : "",
+        range: new vscode.Range(document.positionAt(call.startIndex), document.positionAt(call.endIndex + 1)),
+        documentUri: document.uri.toString(),
+        rawText: call.rawText,
+      });
+    }
+  }
+
+  return dialogs;
+}
+
+/**
+ * Find OnDialogResponse handlers for a specific dialog ID
+ */
+export function findDialogResponseHandlers(document: vscode.TextDocument, dialogId: string): DialogResponseHandler[] {
+  const text = document.getText();
+  const handlers: DialogResponseHandler[] = [];
+
+  // Pattern 1: case DIALOGID: or case dialogid:
+  const caseRegex = new RegExp(`case\\s+${escapeRegex(dialogId)}\\s*:`, "gi");
+  let match;
+
+  while ((match = caseRegex.exec(text)) !== null) {
+    const startPos = document.positionAt(match.index);
+    const endPos = document.positionAt(match.index + match[0].length);
+    handlers.push({
+      dialogId,
+      range: new vscode.Range(startPos, endPos),
+      documentUri: document.uri.toString(),
+    });
+  }
+
+  // Pattern 2: if(dialogid == DIALOGID) or if(dialogid == dialogid)
+  const ifRegex = new RegExp(`if\\s*\\(\\s*dialogid\\s*==\\s*${escapeRegex(dialogId)}\\s*\\)`, "gi");
+
+  while ((match = ifRegex.exec(text)) !== null) {
+    const startPos = document.positionAt(match.index);
+    const endPos = document.positionAt(match.index + match[0].length);
+    handlers.push({
+      dialogId,
+      range: new vscode.Range(startPos, endPos),
+      documentUri: document.uri.toString(),
+    });
+  }
+
+  return handlers;
+}
+
+/**
+ * Find all dialogs across workspace
+ */
+export async function findAllDialogsInWorkspace(): Promise<SAMPDialog[]> {
+  const allDialogs: SAMPDialog[] = [];
+  const files = await vscode.workspace.findFiles("**/*.{pwn,inc}", "**/node_modules/**");
+
+  for (const file of files) {
+    const document = await vscode.workspace.openTextDocument(file);
+    const dialogs = parseDialogs(document);
+    allDialogs.push(...dialogs);
+  }
+
+  return allDialogs;
+}
+
+/**
+ * Find listitem handler (case X:) within a dialog's response handler
+ */
+export function findListItemHandler(document: vscode.TextDocument, dialogId: string, listitem: number): DialogResponseHandler | null {
+  const text = document.getText();
+
+  // First find the dialog handler section
+  const dialogHandlerRegex = new RegExp(`case\\s+${escapeRegex(dialogId)}\\s*:`, "gi");
+  let dialogMatch = dialogHandlerRegex.exec(text);
+
+  if (!dialogMatch) {
+    const ifRegex = new RegExp(`if\\s*\\(\\s*dialogid\\s*==\\s*${escapeRegex(dialogId)}\\s*\\)`, "gi");
+    dialogMatch = ifRegex.exec(text);
+  }
+
+  if (!dialogMatch) return null;
+
+  // Search for case listitem: after the dialog handler
+  const afterDialogText = text.substring(dialogMatch.index);
+  const listitemRegex = new RegExp(`case\\s+${listitem}\\s*:`, "g");
+  const listitemMatch = listitemRegex.exec(afterDialogText);
+
+  if (listitemMatch) {
+    const absoluteIndex = dialogMatch.index + listitemMatch.index;
+    const startPos = document.positionAt(absoluteIndex);
+    const endPos = document.positionAt(absoluteIndex + listitemMatch[0].length);
+
+    return {
+      dialogId: `${dialogId}:${listitem}`,
+      range: new vscode.Range(startPos, endPos),
+      documentUri: document.uri.toString(),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Escape special regex characters
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Parse dialog style from argument string
+ */
+function parseDialogStyle(styleArg: string): DialogStyle {
+  const trimmed = styleArg.trim();
+
+  // Check for named constants
+  if (trimmed.includes("DIALOG_STYLE_MSGBOX") || trimmed === "0") {
+    return DialogStyle.MSGBOX;
+  }
+  if (trimmed.includes("DIALOG_STYLE_INPUT") || trimmed === "1") {
+    return DialogStyle.INPUT;
+  }
+  if (trimmed.includes("DIALOG_STYLE_LIST") || trimmed === "2") {
+    return DialogStyle.LIST;
+  }
+  if (trimmed.includes("DIALOG_STYLE_PASSWORD") || trimmed === "3") {
+    return DialogStyle.PASSWORD;
+  }
+  if (trimmed.includes("DIALOG_STYLE_TABLIST_HEADERS") || trimmed === "5") {
+    return DialogStyle.TABLIST_HEADERS;
+  }
+  if (trimmed.includes("DIALOG_STYLE_TABLIST") || trimmed === "4") {
+    return DialogStyle.TABLIST;
+  }
+
+  // Try to parse as number
+  const num = parseInt(trimmed, 10);
+  if (!isNaN(num) && num >= 0 && num <= 5) {
+    return num as DialogStyle;
+  }
+
+  return DialogStyle.MSGBOX; // Default
+}
+
+/**
+ * Extract string content from a Pawn string argument
+ * Handles concatenation, multi-line with \, etc.
+ */
+function extractStringContent(arg: string): string {
+  let content = "";
+  const trimmed = arg.trim();
+  const captureAllTopLevel = trimmed.startsWith('"');
+  const maxDepth = captureAllTopLevel ? 0 : 1;
+  const maxCaptures = captureAllTopLevel ? Infinity : 1;
+  let captures = 0;
+
+  let depth = 0;
+  let inString = false;
+  let literal = "";
+  let literalDepth = 0;
+
+  for (let i = 0; i < arg.length; i++) {
+    const ch = arg[i];
+
+    if (inString) {
+      if (ch === '"' && !isEscaped(arg, i)) {
+        inString = false;
+        if (literalDepth <= maxDepth && captures < maxCaptures) {
+          content += processEscapeSequences(literal);
+          captures++;
+          if (!captureAllTopLevel) break;
+        }
+        literal = "";
+      } else {
+        literal += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      literal = "";
+      literalDepth = depth;
+      continue;
+    }
+
+    if (ch === "(") {
+      depth++;
+    } else if (ch === ")" && depth > 0) {
+      depth--;
+    }
+  }
+
+  return content;
+}
+
+function resolveDialogArgumentText(text: string, arg: string, beforeIndex: number): string {
+  const literal = extractStringContent(arg);
+  if (literal) return literal;
+
+  const identifier = extractIdentifierArgument(arg);
+  if (!identifier) return "";
+
+  const formatCall = findLatestFormatCallForIdentifier(text, identifier, beforeIndex);
+  if (!formatCall || formatCall.args.length < 3) return "";
+
+  const template = extractStringContent(formatCall.args[2]);
+  if (!template) return "";
+
+  return applyFormatArguments(template, formatCall.args.slice(3)).text;
+}
+
+function resolveFormattedDialogText(text: string, stringArgs: string[], formatArgs: string[], beforeIndex: number): [string, string, string, string] {
+  const result: string[] = [];
+  let formatArgIndex = 0;
+
+  for (const arg of stringArgs) {
+    const resolved = resolveDialogArgumentText(text, arg, beforeIndex);
+    const formatted = applyFormatArguments(resolved, formatArgs.slice(formatArgIndex));
+    result.push(formatted.text);
+    formatArgIndex += formatted.usedArgs;
+  }
+
+  return [result[0] || "", result[1] || "", result[2] || "", result[3] || ""];
+}
+
+function getPaginatedDialogInfoArgument(text: string, headerArg: string, beforeIndex: number): string {
+  const parts: string[] = [];
+  const header = extractStringContent(headerArg);
+  if (header) parts.push(header);
+
+  for (const call of findFunctionCalls(text, "AddPaginatedDialogRow")) {
+    if (call.startIndex >= beforeIndex) continue;
+
+    const row = extractStringContent(call.args[1] || "");
+    if (row) parts.push(row);
+  }
+
+  return JSON.stringify(parts.join(""));
+}
+
+function extractIdentifierArgument(arg: string): string | null {
+  const trimmed = arg.trim();
+  const tagged = trimmed.match(/^(?:[A-Za-z_][A-Za-z0-9_]*:)?([A-Za-z_][A-Za-z0-9_]*)$/);
+  return tagged ? tagged[1] : null;
+}
+
+function findLatestFormatCallForIdentifier(
+  text: string,
+  identifier: string,
+  beforeIndex: number
+): { args: string[]; startIndex: number; endIndex: number; rawText: string } | null {
+  let latest: { args: string[]; startIndex: number; endIndex: number; rawText: string } | null = null;
+
+  for (const call of findFunctionCalls(text, "format")) {
+    if (call.startIndex >= beforeIndex) continue;
+    if (extractIdentifierArgument(call.args[0] || "") !== identifier) continue;
+    latest = call;
+  }
+
+  return latest;
+}
+
+function applyFormatArguments(template: string, args: string[]): { text: string; usedArgs: number } {
+  let argIndex = 0;
+
+  const text = template.replace(/%[-+0# ]*\d*(?:\.\d+)?[A-Za-z%]/g, (specifier) => {
+    if (specifier.endsWith("%")) return "%";
+
+    const replacement = args[argIndex++];
+    if (replacement === undefined) return specifier;
+
+    return cleanPreviewExpression(replacement);
+  });
+
+  return { text, usedArgs: argIndex };
+}
+
+function cleanPreviewExpression(expression: string): string {
+  const literal = extractStringContent(expression);
+  if (literal) return literal;
+
+  return expression
+    .trim()
+    .replace(/^(?:[A-Za-z_][A-Za-z0-9_]*|\{[^}]+\}):\s*/, "")
+    .replace(/\s+/g, " ");
+}
+
+function isEscaped(text: string, index: number): boolean {
+  let backslashes = 0;
+  for (let i = index - 1; i >= 0 && text[i] === "\\"; i--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+/**
+ * Process escape sequences in string content
+ */
+function processEscapeSequences(text: string): string {
+  return text.replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+}
+
+function findFunctionCalls(text: string, name: string): Array<{ args: string[]; startIndex: number; endIndex: number; rawText: string }> {
+  const calls: Array<{ args: string[]; startIndex: number; endIndex: number; rawText: string }> = [];
+  const nameRegex = new RegExp(`\\b${escapeRegex(name)}\\s*\\(`, "g");
+  let match;
+
+  while ((match = nameRegex.exec(text)) !== null) {
+    const startIndex = match.index;
+    const openParenIndex = match.index + match[0].lastIndexOf("(");
+    const parsed = parseFunctionArgs(text, openParenIndex + 1);
+    if (!parsed) continue;
+
+    const { args, endIndex } = parsed;
+    calls.push({
+      args,
+      startIndex,
+      endIndex,
+      rawText: text.substring(startIndex, endIndex + 1),
+    });
+  }
+
+  return calls;
+}
+
+function parseFunctionArgs(text: string, startIndex: number): { args: string[]; endIndex: number } | null {
+  const args: string[] = [];
+  let current = "";
+  let depth = 0;
+  let inString = false;
+
+  for (let i = startIndex; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      current += ch;
+      if (ch === '"' && !isEscaped(text, i)) {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      current += ch;
+      continue;
+    }
+
+    if (ch === "(") {
+      depth++;
+      current += ch;
+      continue;
+    }
+
+    if (ch === ")") {
+      if (depth === 0) {
+        if (current.trim().length > 0) {
+          args.push(current.trim());
+        }
+        return { args, endIndex: i };
+      }
+      depth--;
+      current += ch;
+      continue;
+    }
+
+    if (ch === "," && depth === 0) {
+      args.push(current.trim());
+      current = "";
+      continue;
+    }
+
+    current += ch;
+  }
+
+  return null;
+}
+
+/**
+ * Parse color codes from text and return segments
+ */
+export function parseColorCodes(text: string): ColorSegment[] {
+  const segments: ColorSegment[] = [];
+  const colorRegex = /\{([0-9A-Fa-f]{6})\}/g;
+
+  let lastIndex = 0;
+  let currentColor: string | null = null;
+  let match;
+
+  while ((match = colorRegex.exec(text)) !== null) {
+    // Add text before color code with current color
+    if (match.index > lastIndex) {
+      const textBefore = text.substring(lastIndex, match.index);
+      if (textBefore) {
+        segments.push({ text: textBefore, color: currentColor });
+      }
+    }
+
+    // Update current color
+    currentColor = "#" + match[1];
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    segments.push({ text: text.substring(lastIndex), color: currentColor });
+  }
+
+  // If no segments, return the whole text as one segment
+  if (segments.length === 0 && text) {
+    segments.push({ text, color: null });
+  }
+
+  return segments;
+}
+
+/**
+ * Parse list items from dialog info text
+ * For LIST, TABLIST, TABLIST_HEADERS styles
+ */
+export function parseListItems(info: string, style: DialogStyle): DialogListItem[] {
+  const lines = info.split("\n");
+  const items: DialogListItem[] = [];
+
+  // For TABLIST_HEADERS, first line is headers (skip for list items but include for display)
+  const startIndex = 0;
+
+  for (let i = startIndex; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+
+    if (style === DialogStyle.LIST) {
+      // LIST style: each line is a single item
+      items.push({
+        columns: [parseColorCodes(line)],
+        rawText: line,
+      });
+    } else {
+      // TABLIST/TABLIST_HEADERS: split by tabs
+      const columns = line.split("\t").map((col) => parseColorCodes(col));
+      items.push({
+        columns,
+        rawText: line,
+      });
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Parse headers for TABLIST_HEADERS style
+ */
+export function parseHeaders(info: string): ColorSegment[][] {
+  const lines = info.split("\n");
+  if (lines.length === 0) return [];
+
+  const headerLine = lines[0];
+  return headerLine.split("\t").map((col) => parseColorCodes(col));
+}
+
+/**
+ * Strip color codes from text (for plain text display)
+ */
+export function stripColorCodes(text: string): string {
+  return text.replace(/\{[0-9A-Fa-f]{6}\}/g, "");
+}

--- a/src/client/dialog/previewPanel.ts
+++ b/src/client/dialog/previewPanel.ts
@@ -1,0 +1,751 @@
+import * as vscode from "vscode";
+import { SAMPDialog, DialogStyle, ColorSegment } from "./types";
+import { parseColorCodes, parseListItems, parseHeaders, parseDialogs } from "./parser";
+
+export class DialogPreviewPanel {
+  public static currentPanel: DialogPreviewPanel | undefined;
+  private readonly _panel: vscode.WebviewPanel;
+  private readonly _extensionUri: vscode.Uri;
+  private _disposables: vscode.Disposable[] = [];
+  private _currentDialog: SAMPDialog | undefined;
+  private _allDialogs: SAMPDialog[] = [];
+  private _currentIndex = 0;
+
+  public static createOrShow(extensionUri: vscode.Uri, dialog: SAMPDialog, allDialogs: SAMPDialog[] = []) {
+    const column = vscode.ViewColumn.Beside;
+
+    if (DialogPreviewPanel.currentPanel) {
+      DialogPreviewPanel.currentPanel._panel.reveal(column);
+      DialogPreviewPanel.currentPanel._allDialogs = allDialogs;
+      DialogPreviewPanel.currentPanel._updateCurrentIndex(dialog);
+      DialogPreviewPanel.currentPanel._update(dialog);
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel("sampDialogPreview", "open.mp Dialog Preview", column, {
+      enableScripts: true,
+    });
+
+    DialogPreviewPanel.currentPanel = new DialogPreviewPanel(panel, extensionUri, dialog, allDialogs);
+  }
+
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, dialog: SAMPDialog, allDialogs: SAMPDialog[] = []) {
+    this._panel = panel;
+    this._extensionUri = extensionUri;
+    this._allDialogs = allDialogs;
+    this._updateCurrentIndex(dialog);
+
+    this._update(dialog);
+
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+    vscode.workspace.onDidChangeTextDocument(
+      (event) => {
+        if (!this._currentDialog) return;
+        if (event.document.uri.toString() !== this._currentDialog.documentUri) return;
+        this._refreshFromDocument(event.document);
+      },
+      null,
+      this._disposables,
+    );
+
+    // Handle messages from webview
+    this._panel.webview.onDidReceiveMessage(
+      (message) => {
+        switch (message.command) {
+          case "goToHandler":
+            vscode.commands.executeCommand("pawn-development.goToDialogHandler", this._currentDialog);
+            break;
+          case "goToDialog":
+            vscode.commands.executeCommand("pawn-development.goToDialog", this._currentDialog);
+            break;
+          case "previousDialog":
+            this._navigateDialog(-1);
+            break;
+          case "nextDialog":
+            this._navigateDialog(1);
+            break;
+          case "selectListItem":
+            vscode.commands.executeCommand("pawn-development.goToListItemHandler", this._currentDialog, message.listitem);
+            break;
+        }
+      },
+      null,
+      this._disposables,
+    );
+  }
+
+  private _updateCurrentIndex(dialog: SAMPDialog) {
+    this._currentIndex = this._allDialogs.findIndex(
+      (d) => d.range.start.line === dialog.range.start.line && d.documentUri === dialog.documentUri,
+    );
+    if (this._currentIndex === -1) this._currentIndex = 0;
+  }
+
+  private _navigateDialog(direction: number) {
+    if (this._allDialogs.length === 0) return;
+
+    this._currentIndex = (this._currentIndex + direction + this._allDialogs.length) % this._allDialogs.length;
+    const newDialog = this._allDialogs[this._currentIndex];
+    this._update(newDialog);
+
+    // Also navigate to the dialog in the editor
+    vscode.commands.executeCommand("pawn-development.goToDialog", newDialog);
+  }
+
+  public dispose() {
+    DialogPreviewPanel.currentPanel = undefined;
+
+    this._panel.dispose();
+
+    while (this._disposables.length) {
+      const disposable = this._disposables.pop();
+      if (disposable) {
+        disposable.dispose();
+      }
+    }
+  }
+
+  private _update(dialog: SAMPDialog) {
+    this._currentDialog = dialog;
+    this._panel.webview.html = this._getHtmlForWebview(dialog);
+  }
+
+  private _refreshFromDocument(document: vscode.TextDocument) {
+    const dialogs = parseDialogs(document);
+    this._allDialogs = dialogs;
+    const currentLine = this._currentDialog?.range.start.line ?? 0;
+
+    const sameLine = dialogs.find((d) => d.range.start.line <= currentLine && d.range.end.line >= currentLine);
+    const byId = dialogs.find((d) => d.dialogId === this._currentDialog?.dialogId);
+    const nextDialog = sameLine || byId || dialogs[0];
+
+    if (nextDialog) {
+      this._updateCurrentIndex(nextDialog);
+      this._update(nextDialog);
+    }
+  }
+
+  private _getHtmlForWebview(dialog: SAMPDialog): string {
+    const styleContent = this._getStyles();
+    const dialogContent = this._renderDialog(dialog);
+    const dialogCount = this._allDialogs.length;
+    const currentNum = this._currentIndex + 1;
+    const showId = dialog.dialogId && !dialog.dialogId.startsWith("[");
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SA-MP Dialog Preview</title>
+    <style>${styleContent}</style>
+</head>
+<body>
+    <div class="toolbar">
+        <div class="toolbar-left">
+            <div class="toolbar-title">open.mp Dialog Preview</div>
+            <div class="toolbar-nav">
+                <button class="toolbar-btn" onclick="previousDialog()" title="Previous Dialog">Prev</button>
+                <span class="toolbar-info">${currentNum} / ${dialogCount}</span>
+                <button class="toolbar-btn" onclick="nextDialog()" title="Next Dialog">Next</button>
+            </div>
+        </div>
+        <div class="toolbar-center">
+            ${showId ? `<span class="toolbar-id">${this._escapeHtml(dialog.dialogId)}</span>` : ""}
+        </div>
+        <div class="toolbar-right">
+            <button class="toolbar-btn" onclick="goToDialog()" title="Jump to dialog callsite">Go to Dialog</button>
+            <button class="toolbar-btn" onclick="goToHandler()" title="Jump to dialog handler">Go to Handler</button>
+        </div>
+    </div>
+    <div class="preview-container">
+        <div class="zoom-controls" role="group" aria-label="Zoom controls">
+            <button class="toolbar-btn" onclick="zoomOut()" title="Zoom out">-</button>
+            <span class="toolbar-info" id="zoom-level">100%</span>
+            <button class="toolbar-btn" onclick="zoomIn()" title="Zoom in">+</button>
+            <button class="toolbar-btn" onclick="zoomReset()" title="Reset zoom">Reset</button>
+        </div>
+        <div class="dialog-wrapper">
+            ${dialogContent}
+        </div>
+    </div>
+    <script>
+        const vscode = acquireVsCodeApi();
+        let zoomLevel = 1;
+
+        function setZoom(level) {
+            zoomLevel = Math.min(1.6, Math.max(0.6, level));
+            const wrapper = document.querySelector('.dialog-wrapper');
+            if (wrapper) {
+                wrapper.style.transform = 'scale(' + zoomLevel.toFixed(2) + ')';
+            }
+            const label = document.getElementById('zoom-level');
+            if (label) {
+                label.textContent = Math.round(zoomLevel * 100) + '%';
+            }
+        }
+
+        function previousDialog() {
+            vscode.postMessage({ command: 'previousDialog' });
+        }
+
+        function nextDialog() {
+            vscode.postMessage({ command: 'nextDialog' });
+        }
+
+        function zoomIn() {
+            setZoom(zoomLevel + 0.1);
+        }
+
+        function zoomOut() {
+            setZoom(zoomLevel - 0.1);
+        }
+
+        function zoomReset() {
+            setZoom(1);
+        }
+
+        function goToDialog() {
+            vscode.postMessage({ command: 'goToDialog' });
+        }
+
+        function goToHandler() {
+            vscode.postMessage({ command: 'goToHandler' });
+        }
+
+        function selectListItem(index) {
+            // Update visual selection
+            document.querySelectorAll('.dialog-list-item, .dialog-tablist-row').forEach((el, i) => {
+                el.classList.toggle('selected', i === index);
+            });
+            // Navigate to handler
+            vscode.postMessage({ command: 'selectListItem', listitem: index });
+        }
+
+        setZoom(1);
+    </script>
+</body>
+</html>`;
+  }
+
+  private _renderDialog(dialog: SAMPDialog): string {
+    const caption = this._renderColorText(parseColorCodes(dialog.caption));
+    const button1 = this._renderColorText(parseColorCodes(dialog.button1));
+    const button2 = dialog.button2 ? this._renderColorText(parseColorCodes(dialog.button2)) : "";
+
+    let content = "";
+
+    switch (dialog.style) {
+      case DialogStyle.MSGBOX:
+        content = this._renderMsgBox(dialog);
+        break;
+      case DialogStyle.INPUT:
+        content = this._renderInput(dialog);
+        break;
+      case DialogStyle.LIST:
+        content = this._renderList(dialog);
+        break;
+      case DialogStyle.PASSWORD:
+        content = this._renderPassword(dialog);
+        break;
+      case DialogStyle.TABLIST:
+        content = this._renderTabList(dialog);
+        break;
+      case DialogStyle.TABLIST_HEADERS:
+        content = this._renderTabListHeaders(dialog);
+        break;
+    }
+
+    const buttons = `
+            <div class="dialog-buttons">
+                <button class="dialog-button primary">${button1}</button>
+                ${button2 ? `<button class="dialog-button secondary">${button2}</button>` : ""}
+            </div>
+        `;
+
+    return `
+            <div class="dialog">
+                <div class="dialog-caption">${caption}</div>
+                <div class="dialog-content">
+                    ${content}
+                </div>
+                ${buttons}
+            </div>
+        `;
+  }
+
+  private _renderMsgBox(dialog: SAMPDialog): string {
+    const info = this._renderMultilineText(dialog.info);
+    return `<div class="dialog-info-text">${info}</div>`;
+  }
+
+  private _renderInput(dialog: SAMPDialog): string {
+    const info = this._renderMultilineText(dialog.info);
+    return `
+            <div class="dialog-info-text">${info}</div>
+            <input type="text" class="dialog-input" placeholder="Enter text..." />
+        `;
+  }
+
+  private _renderPassword(dialog: SAMPDialog): string {
+    const info = this._renderMultilineText(dialog.info);
+    return `
+            <div class="dialog-info-text">${info}</div>
+            <input type="password" class="dialog-input" placeholder="Enter password..." value="********" />
+        `;
+  }
+
+  private _renderList(dialog: SAMPDialog): string {
+    const items = parseListItems(dialog.info, DialogStyle.LIST);
+    let html = '<div class="dialog-list">';
+
+    items.forEach((item, index) => {
+      const itemText = item.columns[0] ? this._renderColorSegments(item.columns[0]) : "";
+      html += `<div class="dialog-list-item${index === 0 ? " selected" : ""}" onclick="selectListItem(${index})" title="Click to go to case ${index}: handler">${itemText}</div>`;
+    });
+
+    html += "</div>";
+    return html;
+  }
+
+  private _renderTabList(dialog: SAMPDialog): string {
+    const items = parseListItems(dialog.info, DialogStyle.TABLIST);
+    let html = '<div class="dialog-tablist">';
+
+    items.forEach((item, index) => {
+      html += `<div class="dialog-tablist-row${index === 0 ? " selected" : ""}" onclick="selectListItem(${index})" title="Click to go to case ${index}: handler">`;
+      item.columns.forEach((col) => {
+        html += `<div class="dialog-tablist-cell">${this._renderColorSegments(col)}</div>`;
+      });
+      html += "</div>";
+    });
+
+    html += "</div>";
+    return html;
+  }
+
+  private _renderTabListHeaders(dialog: SAMPDialog): string {
+    const headers = parseHeaders(dialog.info);
+    const lines = dialog.info.split("\n");
+    const itemsInfo = lines.slice(1).join("\n");
+    const items = parseListItems(itemsInfo, DialogStyle.TABLIST_HEADERS);
+
+    let html = '<div class="dialog-tablist">';
+
+    // Render headers
+    if (headers.length > 0) {
+      html += '<div class="dialog-tablist-header">';
+      headers.forEach((header) => {
+        html += `<div class="dialog-tablist-cell header">${this._renderColorSegments(header)}</div>`;
+      });
+      html += "</div>";
+    }
+
+    // Render items
+    items.forEach((item, index) => {
+      html += `<div class="dialog-tablist-row${index === 0 ? " selected" : ""}" onclick="selectListItem(${index})" title="Click to go to case ${index}: handler">`;
+      item.columns.forEach((col) => {
+        html += `<div class="dialog-tablist-cell">${this._renderColorSegments(col)}</div>`;
+      });
+      html += "</div>";
+    });
+
+    html += "</div>";
+    return html;
+  }
+
+  private _renderMultilineText(text: string): string {
+    const lines = text.split("\n");
+    return lines
+      .map((line) => {
+        const segments = parseColorCodes(line);
+        const rendered = this._renderColorSegments(segments);
+        // Handle tabs
+        return rendered.replace(/\t/g, "&nbsp;&nbsp;&nbsp;&nbsp;");
+      })
+      .join("<br>");
+  }
+
+  private _renderColorText(segments: ColorSegment[]): string {
+    return this._renderColorSegments(segments);
+  }
+
+  private _renderColorSegments(segments: ColorSegment[]): string {
+    return segments
+      .map((segment) => {
+        const escapedText = this._escapeHtml(segment.text);
+        if (segment.color) {
+          return `<span style="color: ${segment.color}">${escapedText}</span>`;
+        }
+        return escapedText;
+      })
+      .join("");
+  }
+
+  private _escapeHtml(text: string): string {
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+  }
+
+  private _getStyleName(style: DialogStyle): string {
+    switch (style) {
+      case DialogStyle.MSGBOX:
+        return "MSGBOX";
+      case DialogStyle.INPUT:
+        return "INPUT";
+      case DialogStyle.LIST:
+        return "LIST";
+      case DialogStyle.PASSWORD:
+        return "PASSWORD";
+      case DialogStyle.TABLIST:
+        return "TABLIST";
+      case DialogStyle.TABLIST_HEADERS:
+        return "TABLIST_HEADERS";
+      default:
+        return "Unknown";
+    }
+  }
+
+  private _getStyles(): string {
+    return `
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+
+            :root {
+                --chrome-bg: #1a202c;
+                --chrome-edge: #2d3748;
+                --chrome-accent: #9083d2;
+                --chrome-muted: #a0aec0;
+                --chrome-text: #e2e8f0;
+                --btn-bg: #2c323d;
+                --btn-bg-hover: #3a4250;
+                --btn-border: #424b5a;
+                --page-bg: #1a202c;
+            }
+
+            @media (prefers-color-scheme: light) {
+                :root {
+                    --chrome-bg: #f7fafc;
+                    --chrome-edge: #e2e8f0;
+                    --chrome-accent: #6b5fb3;
+                    --chrome-muted: #718096;
+                    --chrome-text: #1a202c;
+                    --btn-bg: #edf2f7;
+                    --btn-bg-hover: #e2e8f0;
+                    --btn-border: #cbd5e0;
+                    --page-bg: #f7fafc;
+                }
+            }
+
+            body {
+                font-family: "Trebuchet MS", "Verdana", "Geneva", sans-serif;
+                background: var(--page-bg);
+                margin: 0;
+                padding: 0;
+                min-height: 100vh;
+                display: flex;
+                flex-direction: column;
+                color: var(--chrome-text);
+            }
+
+            .toolbar {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                background: var(--chrome-bg);
+                border-bottom: 1px solid var(--chrome-edge);
+                padding: 6px 10px;
+                position: sticky;
+                top: 0;
+                z-index: 100;
+                box-shadow: 0 8px 14px rgba(0, 0, 0, 0.25);
+            }
+
+            .toolbar-left,
+            .toolbar-center,
+            .toolbar-right {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
+
+            .toolbar-left {
+                gap: 10px;
+            }
+
+            .toolbar-title {
+                font-size: 13px;
+                font-weight: 700;
+                letter-spacing: 0.6px;
+                text-transform: uppercase;
+                color: var(--chrome-text);
+            }
+
+            .toolbar-nav {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                padding: 4px 6px;
+                border: 1px solid var(--chrome-edge);
+                border-radius: 999px;
+                background: rgba(255, 255, 255, 0.03);
+            }
+
+            .toolbar-btn {
+                background: var(--btn-bg);
+                border: 1px solid var(--btn-border);
+                color: var(--chrome-text);
+                padding: 3px 9px;
+                cursor: pointer;
+                font-size: 10px;
+                border-radius: 999px;
+                letter-spacing: 0.2px;
+            }
+
+            .toolbar-btn:hover {
+                background: var(--btn-bg-hover);
+                color: #ffffff;
+            }
+
+            .toolbar-info {
+                color: var(--chrome-muted);
+                font-size: 11px;
+                min-width: 46px;
+                text-align: center;
+            }
+
+            .toolbar-id {
+                color: var(--chrome-accent);
+                font-size: 12px;
+                font-family: "Consolas", "Courier New", monospace;
+                padding: 2px 8px;
+                border-radius: 6px;
+                background: rgba(144, 131, 210, 0.1);
+                border: 1px solid rgba(144, 131, 210, 0.25);
+            }
+
+            .toolbar-style {
+                color: var(--chrome-muted);
+                font-size: 10px;
+                background: rgba(255, 255, 255, 0.05);
+                padding: 3px 8px;
+                border-radius: 999px;
+                text-transform: uppercase;
+                letter-spacing: 0.4px;
+            }
+
+            .preview-container {
+                flex: 1;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                padding: 20px;
+                position: relative;
+            }
+
+            .dialog-wrapper {
+                display: flex;
+                justify-content: center;
+                transform-origin: center center;
+                transition: transform 120ms ease-out;
+            }
+
+            .zoom-controls {
+                position: absolute;
+                right: 16px;
+                bottom: 16px;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                padding: 6px 8px;
+                border-radius: 999px;
+                background: rgba(0, 0, 0, 0.35);
+                border: 1px solid var(--chrome-edge);
+                backdrop-filter: blur(6px);
+            }
+
+            .dialog {
+                background: rgba(0, 0, 0, 0.85);
+                border: 1px solid #4a5568;
+                min-width: 300px;
+                max-width: 500px;
+            }
+
+            .dialog-caption {
+                background: transparent;
+                color: #ffffff;
+                padding: 8px 10px;
+                font-size: 13px;
+                font-weight: normal;
+                border-bottom: 1px solid #4a5568;
+            }
+
+            .dialog-content {
+                padding: 0;
+                color: #ffffff;
+                font-size: 13px;
+                line-height: 1.4;
+            }
+
+            .dialog-info-text {
+                padding: 10px;
+                white-space: pre-wrap;
+            }
+
+            .dialog-input {
+                width: calc(100% - 20px);
+                margin: 10px;
+                padding: 4px 6px;
+                background: #0a0a0a;
+                border: 1px solid #4a5568;
+                color: #ffffff;
+                font-family: Arial, sans-serif;
+                font-size: 13px;
+                outline: none;
+            }
+
+            .dialog-list {
+                background: #0a0a0a;
+                border: 1px solid #4a5568;
+                margin: 8px;
+                max-height: calc(19 * 19px);
+                overflow-y: auto;
+            }
+
+            .dialog-list-item {
+                padding: 1px 6px;
+                cursor: pointer;
+                color: #ffffff;
+                height: 19px;
+                line-height: 17px;
+            }
+
+            .dialog-list-item:hover {
+                background: #3d1a1a;
+            }
+
+            .dialog-list-item.selected {
+                background: #6b1c1c;
+                color: #ffffff;
+            }
+
+            .dialog-tablist {
+                background: #0a0a0a;
+                border: 1px solid #4a5568;
+                margin: 8px;
+                max-height: calc(19 * 19px);
+                overflow-y: auto;
+            }
+
+            .dialog-tablist-header {
+                display: flex;
+                background: #2a2a2a;
+                border-bottom: 1px solid #4a5568;
+                font-weight: bold;
+                color: #ffffff;
+            }
+
+            .dialog-tablist-row {
+                display: flex;
+                cursor: pointer;
+                color: #ffffff;
+                height: 19px;
+                line-height: 17px;
+            }
+
+            .dialog-tablist-row:hover {
+                background: #3d1a1a;
+            }
+
+            .dialog-tablist-row.selected {
+                background: #6b1c1c;
+                color: #ffffff;
+            }
+
+            .dialog-tablist-cell {
+                flex: 1;
+                padding: 1px 6px;
+                min-width: 80px;
+            }
+
+            .dialog-tablist-cell.header {
+                color: #ffffff;
+                padding: 1px 6px;
+            }
+
+            .dialog-buttons {
+                display: flex;
+                justify-content: center;
+                gap: 8px;
+                padding: 10px;
+                border-top: 1px solid #4a5568;
+            }
+
+            .dialog-button {
+                padding: 2px 16px;
+                font-family: Arial, sans-serif;
+                font-size: 12px;
+                cursor: pointer;
+                background: linear-gradient(180deg, #5a5a5a 0%, #3a3a3a 50%, #2a2a2a 51%, #1a1a1a 100%);
+                border: 1px solid #6a6a6a;
+                border-bottom-color: #1a1a1a;
+                border-right-color: #1a1a1a;
+                color: #d0d0d0;
+            }
+
+            .dialog-button:hover {
+                background: linear-gradient(180deg, #6a6a6a 0%, #4a4a4a 50%, #3a3a3a 51%, #2a2a2a 100%);
+            }
+
+            .dialog-button:active {
+                background: linear-gradient(180deg, #2a2a2a 0%, #3a3a3a 50%, #4a4a4a 51%, #5a5a5a 100%);
+            }
+
+            .dialog-button.primary {
+                background: linear-gradient(180deg, #5a5a5a 0%, #3a3a3a 50%, #2a2a2a 51%, #1a1a1a 100%);
+                border: 1px solid #6a6a6a;
+                border-bottom-color: #1a1a1a;
+                border-right-color: #1a1a1a;
+                color: #d0d0d0;
+            }
+
+            .dialog-button.secondary {
+                background: linear-gradient(180deg, #5a5a5a 0%, #3a3a3a 50%, #2a2a2a 51%, #1a1a1a 100%);
+                border: 1px solid #6a6a6a;
+                border-bottom-color: #1a1a1a;
+                border-right-color: #1a1a1a;
+                color: #d0d0d0;
+            }
+
+            /* Scrollbar styling - SA-MP style */
+            ::-webkit-scrollbar {
+                width: 16px;
+                background: #1a1a1a;
+            }
+
+            ::-webkit-scrollbar-track {
+                background: #1a1a1a;
+                border-left: 1px solid #4a5568;
+            }
+
+            ::-webkit-scrollbar-thumb {
+                background: linear-gradient(90deg, #4a4a4a 0%, #3a3a3a 50%, #2a2a2a 100%);
+                border: 1px solid #5a5a5a;
+            }
+
+            ::-webkit-scrollbar-thumb:hover {
+                background: linear-gradient(90deg, #5a5a5a 0%, #4a4a4a 50%, #3a3a3a 100%);
+            }
+
+            ::-webkit-scrollbar-button:vertical:start:decrement,
+            ::-webkit-scrollbar-button:vertical:end:increment {
+                height: 16px;
+                background: linear-gradient(180deg, #4a4a4a 0%, #2a2a2a 100%);
+                border: 1px solid #5a5a5a;
+            }
+        `;
+  }
+}

--- a/src/client/dialog/types.ts
+++ b/src/client/dialog/types.ts
@@ -1,0 +1,87 @@
+import * as vscode from "vscode";
+
+/**
+ * SA-MP Dialog Styles
+ */
+export enum DialogStyle {
+  MSGBOX = 0,
+  INPUT = 1,
+  LIST = 2,
+  PASSWORD = 3,
+  TABLIST = 4,
+  TABLIST_HEADERS = 5,
+}
+
+/**
+ * Represents a parsed SA-MP dialog
+ */
+export interface SAMPDialog {
+  /** The dialog ID (second parameter) */
+  dialogId: string;
+  /** The dialog style (0-5) */
+  style: DialogStyle;
+  /** Dialog window caption/title */
+  caption: string;
+  /** Main dialog content/info text */
+  info: string;
+  /** Left button text (response = 1) */
+  button1: string;
+  /** Right button text (response = 0), empty = hidden */
+  button2: string;
+  /** Position in the source document */
+  range: vscode.Range;
+  /** Document URI */
+  documentUri: string;
+  /** Raw ShowPlayerDialog call text */
+  rawText: string;
+}
+
+/**
+ * Represents a dialog response handler location
+ */
+export interface DialogResponseHandler {
+  /** The dialog ID being handled */
+  dialogId: string;
+  /** Position in the source document */
+  range: vscode.Range;
+  /** Document URI */
+  documentUri: string;
+}
+
+/**
+ * Represents a parsed color segment in dialog text
+ */
+export interface ColorSegment {
+  text: string;
+  color: string | null; // null means default color
+}
+
+/**
+ * Represents a list item in LIST/TABLIST dialogs
+ */
+export interface DialogListItem {
+  columns: ColorSegment[][];
+  rawText: string;
+}
+
+/**
+ * Get the name of a dialog style
+ */
+export function getDialogStyleName(style: DialogStyle): string {
+  switch (style) {
+    case DialogStyle.MSGBOX:
+      return "DIALOG_STYLE_MSGBOX";
+    case DialogStyle.INPUT:
+      return "DIALOG_STYLE_INPUT";
+    case DialogStyle.LIST:
+      return "DIALOG_STYLE_LIST";
+    case DialogStyle.PASSWORD:
+      return "DIALOG_STYLE_PASSWORD";
+    case DialogStyle.TABLIST:
+      return "DIALOG_STYLE_TABLIST";
+    case DialogStyle.TABLIST_HEADERS:
+      return "DIALOG_STYLE_TABLIST_HEADERS";
+    default:
+      return "Unknown";
+  }
+}

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -6,6 +6,20 @@ import path = require("path");
 import { LanguageClient, LanguageClientOptions, ServerOptions, State, TransportKind } from "vscode-languageclient/node";
 import { addToPawnIgnore, InitPawnIgnore } from "./whitelistedpaths";
 import PawnFoldingProvider from "./FoldingProvider";
+import { DialogCodeLensProvider } from "./dialog/codeLensProvider";
+import { DialogPreviewPanel } from "./dialog/previewPanel";
+import { SAMPDialog } from "./dialog/types";
+import { parseDialogs, findDialogResponseHandlers, findListItemHandler } from "./dialog/parser";
+import { MenuCodeLensProvider } from "./menu/codeLensProvider";
+import { MenuPreviewPanel } from "./menu/previewPanel";
+import { PawnMenu } from "./menu/types";
+import { parseMenuPreviews } from "./menu/parser";
+
+// Prevent astyle process.abort hook from crashing the extension host
+// when unhandled stuff occur from other extensions (e.g., Git)
+process.on("unhandledRejection", (reason) => {
+  console.error("Pawn extension caught unhandled rejection:", reason);
+});
 
 export let client: LanguageClient;
 
@@ -17,10 +31,205 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("pawn-development.reloadDefs", () => {
       initSnippetCollector(true);
-    })
+    }),
   );
   context.subscriptions.push(
-    vscode.languages.registerFoldingRangeProvider({ scheme: "file", language: "pawn" }, new PawnFoldingProvider())
+    vscode.languages.registerFoldingRangeProvider({ scheme: "file", language: "pawn" }, new PawnFoldingProvider()),
+  );
+
+  // Register Dialog Preview CodeLens provider
+  const dialogCodeLensProvider = new DialogCodeLensProvider();
+  context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider(
+      [
+        { scheme: "file", language: "pawn" },
+        { scheme: "file", pattern: "**/*.pwn" },
+        { scheme: "file", pattern: "**/*.inc" },
+      ],
+      dialogCodeLensProvider,
+    ),
+  );
+
+  // Register Menu Preview CodeLens provider
+  const menuCodeLensProvider = new MenuCodeLensProvider();
+  context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider(
+      [
+        { scheme: "file", language: "pawn" },
+        { scheme: "file", pattern: "**/*.pwn" },
+        { scheme: "file", pattern: "**/*.inc" },
+      ],
+      menuCodeLensProvider,
+    ),
+  );
+
+  // Register Dialog Preview command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("pawn-development.previewDialog", async (dialog?: SAMPDialog) => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showInformationMessage("No active editor to preview dialogs.");
+        return;
+      }
+
+      const allDialogs = parseDialogs(editor.document);
+
+      if (!dialog) {
+        if (allDialogs.length === 0) {
+          vscode.window.showInformationMessage("No dialogs found in the current file.");
+          return;
+        }
+
+        if (allDialogs.length === 1) {
+          dialog = allDialogs[0];
+        } else {
+          const items = allDialogs.map((d, i) => ({
+            label: `${i + 1}. ${d.caption || "[No title]"}`,
+            description: `${d.style} • line ${d.range.start.line + 1}`,
+            dialog: d,
+          }));
+          const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select a dialog to preview" });
+          if (!picked) return;
+          dialog = picked.dialog;
+        }
+      }
+
+      DialogPreviewPanel.createOrShow(context.extensionUri, dialog, allDialogs);
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("pawn-development.previewMenu", async (menu?: PawnMenu) => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showInformationMessage("No active editor to preview menus.");
+        return;
+      }
+
+      const allMenus = parseMenuPreviews(editor.document);
+
+      if (!menu) {
+        if (allMenus.length === 0) {
+          vscode.window.showInformationMessage("No menus found in the current file.");
+          return;
+        }
+
+        if (allMenus.length === 1) {
+          menu = allMenus[0];
+        } else {
+          const items = allMenus.map((m, i) => ({
+            label: `${i + 1}. ${m.menuName}`,
+            description: `line ${m.range.start.line + 1}`,
+            menu: m,
+          }));
+          const picked = await vscode.window.showQuickPick(items, { placeHolder: "Select a menu to preview" });
+          if (!picked) return;
+          menu = picked.menu;
+        }
+      }
+
+      MenuPreviewPanel.createOrShow(menu, allMenus);
+    }),
+  );
+
+  // Register Go to Dialog command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("pawn-development.goToDialog", async (dialog: SAMPDialog) => {
+      if (!dialog) return;
+
+      const uri = vscode.Uri.parse(dialog.documentUri);
+      const document = await vscode.workspace.openTextDocument(uri);
+      const editor = await vscode.window.showTextDocument(document, vscode.ViewColumn.One);
+
+      editor.selection = new vscode.Selection(dialog.range.start, dialog.range.end);
+      editor.revealRange(dialog.range, vscode.TextEditorRevealType.InCenter);
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("pawn-development.goToMenu", async (menu: PawnMenu) => {
+      if (!menu) return;
+
+      const uri = vscode.Uri.parse(menu.documentUri);
+      const document = await vscode.workspace.openTextDocument(uri);
+      const editor = await vscode.window.showTextDocument(document, vscode.ViewColumn.One);
+
+      editor.selection = new vscode.Selection(menu.range.start, menu.range.end);
+      editor.revealRange(menu.range, vscode.TextEditorRevealType.InCenter);
+    }),
+  );
+
+  // Register Go to Handler command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("pawn-development.goToDialogHandler", async (dialog: SAMPDialog) => {
+      if (!dialog) return;
+
+      const uri = vscode.Uri.parse(dialog.documentUri);
+      const document = await vscode.workspace.openTextDocument(uri);
+      let handlers = findDialogResponseHandlers(document, dialog.dialogId);
+
+      // If not found, search in all workspace files
+      if (handlers.length === 0) {
+        const files = await vscode.workspace.findFiles("**/*.{pwn,inc}", "**/node_modules/**");
+        for (const file of files) {
+          const doc = await vscode.workspace.openTextDocument(file);
+          const found = findDialogResponseHandlers(doc, dialog.dialogId);
+          handlers.push(...found);
+        }
+      }
+
+      if (handlers.length === 0) {
+        vscode.window.showInformationMessage(`No handler found for dialog ID: ${dialog.dialogId}`);
+        return;
+      }
+
+      // If multiple handlers, let user pick
+      if (handlers.length > 1) {
+        const items = handlers.map((h, i) => ({
+          label: `Handler ${i + 1}`,
+          description: `Line ${h.range.start.line + 1}`,
+          handler: h,
+        }));
+
+        const picked = await vscode.window.showQuickPick(items, {
+          placeHolder: "Multiple handlers found. Select one:",
+        });
+
+        if (!picked) return;
+        handlers = [picked.handler];
+      }
+
+      const handler = handlers[0];
+      const handlerUri = vscode.Uri.parse(handler.documentUri);
+      const handlerDoc = await vscode.workspace.openTextDocument(handlerUri);
+      const editor = await vscode.window.showTextDocument(handlerDoc, vscode.ViewColumn.One);
+
+      editor.selection = new vscode.Selection(handler.range.start, handler.range.end);
+      editor.revealRange(handler.range, vscode.TextEditorRevealType.InCenter);
+    }),
+  );
+
+  // Register Go to List Item Handler command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("pawn-development.goToListItemHandler", async (dialog: SAMPDialog, listitem: number) => {
+      if (!dialog) return;
+
+      const uri = vscode.Uri.parse(dialog.documentUri);
+      const document = await vscode.workspace.openTextDocument(uri);
+      const handler = findListItemHandler(document, dialog.dialogId, listitem);
+
+      if (!handler) {
+        vscode.window.showInformationMessage(`No list item handler found for dialog ${dialog.dialogId} (item ${listitem}).`);
+        return;
+      }
+
+      const handlerUri = vscode.Uri.parse(handler.documentUri);
+      const handlerDoc = await vscode.workspace.openTextDocument(handlerUri);
+      const editor = await vscode.window.showTextDocument(handlerDoc, vscode.ViewColumn.One);
+
+      editor.selection = new vscode.Selection(handler.range.start, handler.range.end);
+      editor.revealRange(handler.range, vscode.TextEditorRevealType.InCenter);
+    }),
   );
 
   vscode.languages.registerDocumentFormattingEditProvider("pawn", PawnDocumentFormattingEditProvider);

--- a/src/client/formatter.ts
+++ b/src/client/formatter.ts
@@ -1,5 +1,4 @@
 import * as vscode from "vscode";
-import { format } from "astyle";
 
 interface RegexCodeFix {
   expr: RegExp;
@@ -33,6 +32,71 @@ const afterFix: RegexCodeFix[] = [
   { expr: /(static|const|new) (.*?):\s+/gm, replacement: "$1 $2:" },
 ];
 
+let warnedMissingAstyle = false;
+let astyleFormatPromise: Promise<(text: string, options: string) => Promise<string>> | undefined;
+
+const loadAstyleFormatter = async () => {
+  if (astyleFormatPromise !== undefined) return astyleFormatPromise;
+
+  astyleFormatPromise = (async () => {
+    const listenersBeforeImport = snapshotProcessListeners();
+    const fetchDescriptor = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+
+    try {
+      Object.defineProperty(globalThis, "fetch", {
+        configurable: true,
+        writable: true,
+        value: undefined,
+      });
+      const { format } = (await import("astyle")) as { format: (text: string, options: string) => Promise<string> };
+      return format;
+    } finally {
+      if (fetchDescriptor !== undefined) {
+        Object.defineProperty(globalThis, "fetch", fetchDescriptor);
+      } else {
+        delete (globalThis as { fetch?: unknown }).fetch;
+      }
+      removeNewProcessListeners(listenersBeforeImport);
+    }
+  })();
+
+  return astyleFormatPromise;
+};
+
+type ProcessListenerSnapshot = Map<string, Set<Function>>;
+type GuardedProcessEvent = "unhandledRejection" | "uncaughtException";
+type ProcessEventEmitter = {
+  listeners(event: string): Function[];
+  removeListener(event: string, listener: Function): void;
+};
+const guardedProcessEvents: GuardedProcessEvent[] = ["unhandledRejection", "uncaughtException"];
+
+const snapshotProcessListeners = (): ProcessListenerSnapshot => {
+  const snapshot: ProcessListenerSnapshot = new Map();
+  const processEvents = process as ProcessEventEmitter;
+
+  for (const event of guardedProcessEvents) {
+    snapshot.set(event, new Set(processEvents.listeners(event)));
+  }
+
+  return snapshot;
+};
+
+const removeNewProcessListeners = (snapshot: ProcessListenerSnapshot) => {
+  const processEvents = process as ProcessEventEmitter;
+
+  for (const event of guardedProcessEvents) {
+    const previousListeners = snapshot.get(event);
+    if (previousListeners === undefined) continue;
+
+    for (const listener of processEvents.listeners(event)) {
+      if (!previousListeners.has(listener)) {
+        processEvents.removeListener(event, listener);
+      }
+    }
+  }
+};
+
 const formatPawn = async (content: string) => {
   const brace_style = vscode.workspace.getConfiguration().get("pawn.language.brace_style") as
     | "Allman"
@@ -40,6 +104,8 @@ const formatPawn = async (content: string) => {
     | "Stroustrup"
     | "Google"
     | null;
+
+  const originalContent = content;
 
   for (const key in beforeFix) {
     const element = beforeFix[key];
@@ -68,7 +134,18 @@ const formatPawn = async (content: string) => {
     "--attach-return-type",
   ];
 
-  content = await format(content, formatterConfig.join(" "));
+  try {
+    const format = await loadAstyleFormatter();
+    content = await format(content, formatterConfig.join(" "));
+  } catch (error) {
+    console.error("Pawn formatter error:", error);
+    if (!warnedMissingAstyle) {
+      warnedMissingAstyle = true;
+      vscode.window.showWarningMessage("Pawn formatter is unavailable (missing 'astyle'). Formatting skipped.");
+    }
+    return originalContent; // Return original content on error
+  }
+
   for (const key in afterFix) {
     const element = afterFix[key];
     content = content.replace(element.expr, element.replacement);

--- a/src/client/menu/codeLensProvider.ts
+++ b/src/client/menu/codeLensProvider.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+import { parseMenuPreviews } from "./parser";
+
+export class MenuCodeLensProvider implements vscode.CodeLensProvider {
+  private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+  public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+
+  constructor() {
+    vscode.workspace.onDidChangeTextDocument(() => {
+      this._onDidChangeCodeLenses.fire();
+    });
+  }
+
+  public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+    const codeLenses: vscode.CodeLens[] = [];
+    const menus = parseMenuPreviews(document);
+
+    for (const menu of menus) {
+      const codeLens = new vscode.CodeLens(menu.range, {
+        title: "$(eye) Preview Menu",
+        command: "pawn-development.previewMenu",
+        arguments: [menu],
+      });
+      codeLenses.push(codeLens);
+    }
+
+    return codeLenses;
+  }
+
+  public resolveCodeLens(codeLens: vscode.CodeLens): vscode.CodeLens {
+    return codeLens;
+  }
+
+  public refresh(): void {
+    this._onDidChangeCodeLenses.fire();
+  }
+}

--- a/src/client/menu/parser.ts
+++ b/src/client/menu/parser.ts
@@ -1,0 +1,200 @@
+import * as vscode from "vscode";
+import { ColorSegment } from "../dialog/types";
+import { parseColorCodes } from "../dialog/parser";
+import { PawnMenu } from "./types";
+
+type FunctionCall = {
+  args: string[];
+  startIndex: number;
+  endIndex: number;
+  rawText: string;
+};
+
+const stringRegex = /"((?:[^"\\]|\\.)*)"/g;
+
+const isEscaped = (text: string, index: number) => {
+  let backslashes = 0;
+  for (let i = index - 1; i >= 0 && text[i] === "\\"; i--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+};
+
+const processEscapeSequences = (text: string) => {
+  return text.replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+};
+
+const extractStringContent = (arg: string) => {
+  let content = "";
+  let match;
+  while ((match = stringRegex.exec(arg)) !== null) {
+    content += match[1];
+  }
+  return processEscapeSequences(content);
+};
+
+const normalizeIdentifier = (arg: string) => {
+  const trimmed = arg.trim();
+  const match = trimmed.match(/[A-Za-z_@][\w:@]*/);
+  if (!match) return "";
+  const raw = match[0];
+  const parts = raw.split(":");
+  return parts[parts.length - 1] || raw;
+};
+
+const findAssignedIdentifier = (text: string, startIndex: number) => {
+  let i = startIndex - 1;
+  while (i >= 0 && /\s/.test(text[i])) i--;
+  if (i < 0 || text[i] !== "=") return "";
+  i--;
+  while (i >= 0 && /\s/.test(text[i])) i--;
+  const end = i;
+  while (i >= 0 && /[\w:]/.test(text[i])) i--;
+  const raw = text.slice(i + 1, end + 1);
+  const parts = raw.split(":");
+  return parts[parts.length - 1] || raw;
+};
+
+const findFunctionCalls = (text: string, name: string): FunctionCall[] => {
+  const calls: FunctionCall[] = [];
+  const nameRegex = new RegExp(`\\b${escapeRegex(name)}\\s*\\(`, "g");
+  let match;
+
+  while ((match = nameRegex.exec(text)) !== null) {
+    const startIndex = match.index;
+    const openParenIndex = match.index + match[0].lastIndexOf("(");
+    const parsed = parseFunctionArgs(text, openParenIndex + 1);
+    if (!parsed) continue;
+
+    const { args, endIndex } = parsed;
+    calls.push({
+      args,
+      startIndex,
+      endIndex,
+      rawText: text.substring(startIndex, endIndex + 1),
+    });
+  }
+
+  return calls;
+};
+
+const parseFunctionArgs = (text: string, startIndex: number): { args: string[]; endIndex: number } | null => {
+  const args: string[] = [];
+  let current = "";
+  let depth = 0;
+  let inString = false;
+
+  for (let i = startIndex; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      current += ch;
+      if (ch === '"' && !isEscaped(text, i)) {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      current += ch;
+      continue;
+    }
+
+    if (ch === "(") {
+      depth++;
+      current += ch;
+      continue;
+    }
+
+    if (ch === ")") {
+      if (depth === 0) {
+        if (current.trim().length > 0) {
+          args.push(current.trim());
+        }
+        return { args, endIndex: i };
+      }
+      depth--;
+      current += ch;
+      continue;
+    }
+
+    if (ch === "," && depth === 0) {
+      args.push(current.trim());
+      current = "";
+      continue;
+    }
+
+    current += ch;
+  }
+
+  return null;
+};
+
+const escapeRegex = (str: string) => {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+};
+
+const parseMenuTitle = (arg: string) => {
+  const title = extractStringContent(arg);
+  return parseColorCodes(title);
+};
+
+const parseMenuItem = (arg: string) => {
+  const text = extractStringContent(arg) || arg.trim();
+  return parseColorCodes(text);
+};
+
+const parseMenuColumns = (arg: string) => {
+  const num = parseInt(arg.replace(/[^\d-]/g, ""), 10);
+  if (!isNaN(num) && num > 0) return num;
+  return 1;
+};
+
+export function parseMenuPreviews(document: vscode.TextDocument): PawnMenu[] {
+  const text = document.getText();
+  const menus = new Map<string, { title: ColorSegment[]; columns: number; items: ColorSegment[][][] }>();
+
+  for (const call of findFunctionCalls(text, "CreateMenu")) {
+    if (call.args.length < 2) continue;
+    const menuName = findAssignedIdentifier(text, call.startIndex);
+    if (!menuName) continue;
+    const title = parseMenuTitle(call.args[0] || '""');
+    const columns = parseMenuColumns(call.args[1] || "1");
+    const items = Array.from({ length: columns }, () => []);
+    menus.set(menuName, { title, columns, items });
+  }
+
+  for (const call of findFunctionCalls(text, "AddMenuItem")) {
+    if (call.args.length < 3) continue;
+    const menuName = normalizeIdentifier(call.args[0]);
+    if (!menuName) continue;
+    const menu = menus.get(menuName);
+    if (!menu) continue;
+    const columnIndex = parseInt(call.args[1] || "0", 10);
+    if (isNaN(columnIndex) || columnIndex < 0 || columnIndex >= menu.columns) continue;
+    menu.items[columnIndex].push(parseMenuItem(call.args[2]));
+  }
+
+  const previews: PawnMenu[] = [];
+  for (const call of findFunctionCalls(text, "ShowMenuForPlayer")) {
+    if (call.args.length < 1) continue;
+    const menuName = normalizeIdentifier(call.args[0]);
+    if (!menuName) continue;
+    const menu = menus.get(menuName);
+    if (!menu) continue;
+    const startPos = document.positionAt(call.startIndex);
+    const endPos = document.positionAt(call.endIndex + 1);
+    previews.push({
+      menuName,
+      title: menu.title,
+      columns: menu.columns,
+      items: menu.items,
+      range: new vscode.Range(startPos, endPos),
+      documentUri: document.uri.toString(),
+      rawText: call.rawText,
+    });
+  }
+
+  return previews;
+}

--- a/src/client/menu/previewPanel.ts
+++ b/src/client/menu/previewPanel.ts
@@ -1,0 +1,407 @@
+import * as vscode from "vscode";
+import { PawnMenu } from "./types";
+import { ColorSegment } from "../dialog/types";
+
+export class MenuPreviewPanel {
+  public static currentPanel: MenuPreviewPanel | undefined;
+  private readonly _panel: vscode.WebviewPanel;
+  private _disposables: vscode.Disposable[] = [];
+  private _currentMenu: PawnMenu | undefined;
+  private _allMenus: PawnMenu[] = [];
+  private _currentIndex = 0;
+
+  public static createOrShow(menu: PawnMenu, allMenus: PawnMenu[] = []) {
+    const column = vscode.ViewColumn.Beside;
+
+    if (MenuPreviewPanel.currentPanel) {
+      MenuPreviewPanel.currentPanel._panel.reveal(column);
+      MenuPreviewPanel.currentPanel._allMenus = allMenus;
+      MenuPreviewPanel.currentPanel._updateCurrentIndex(menu);
+      MenuPreviewPanel.currentPanel._update(menu);
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel("pawnMenuPreview", "open.mp Menu Preview", column, {
+      enableScripts: true,
+    });
+
+    MenuPreviewPanel.currentPanel = new MenuPreviewPanel(panel, menu, allMenus);
+  }
+
+  private constructor(panel: vscode.WebviewPanel, menu: PawnMenu, allMenus: PawnMenu[] = []) {
+    this._panel = panel;
+    this._allMenus = allMenus;
+    this._updateCurrentIndex(menu);
+    this._update(menu);
+
+    this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+    this._panel.webview.onDidReceiveMessage(
+      (message) => {
+        switch (message.command) {
+          case "goToMenu":
+            vscode.commands.executeCommand("pawn-development.goToMenu", this._currentMenu);
+            break;
+          case "previousMenu":
+            this._navigateMenu(-1);
+            break;
+          case "nextMenu":
+            this._navigateMenu(1);
+            break;
+        }
+      },
+      null,
+      this._disposables,
+    );
+  }
+
+  private _updateCurrentIndex(menu: PawnMenu) {
+    this._currentIndex = this._allMenus.findIndex(
+      (m) => m.range.start.line === menu.range.start.line && m.documentUri === menu.documentUri,
+    );
+    if (this._currentIndex === -1) this._currentIndex = 0;
+  }
+
+  private _navigateMenu(direction: number) {
+    if (this._allMenus.length === 0) return;
+
+    this._currentIndex = (this._currentIndex + direction + this._allMenus.length) % this._allMenus.length;
+    const newMenu = this._allMenus[this._currentIndex];
+    this._update(newMenu);
+  }
+
+  public dispose() {
+    MenuPreviewPanel.currentPanel = undefined;
+
+    this._panel.dispose();
+
+    while (this._disposables.length) {
+      const disposable = this._disposables.pop();
+      if (disposable) {
+        disposable.dispose();
+      }
+    }
+  }
+
+  private _update(menu: PawnMenu) {
+    this._currentMenu = menu;
+    this._panel.webview.html = this._getHtmlForWebview(menu);
+  }
+
+  private _getHtmlForWebview(menu: PawnMenu): string {
+    const styleContent = this._getStyles();
+    const menuContent = this._renderMenu(menu);
+    const menuCount = this._allMenus.length;
+    const currentNum = this._currentIndex + 1;
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>open.mp Menu Preview</title>
+    <style>${styleContent}</style>
+</head>
+<body>
+    <div class="toolbar">
+        <div class="toolbar-left">
+            <div class="toolbar-title">open.mp Menu Preview</div>
+            <div class="toolbar-nav">
+                <button class="toolbar-btn" onclick="previousMenu()" title="Previous Menu">Prev</button>
+                <span class="toolbar-info">${currentNum} / ${menuCount}</span>
+                <button class="toolbar-btn" onclick="nextMenu()" title="Next Menu">Next</button>
+            </div>
+        </div>
+        <div class="toolbar-right">
+            <button class="toolbar-btn" onclick="goToMenu()">Go to Menu</button>
+        </div>
+    </div>
+    <div class="preview-container">
+        <div class="zoom-controls" role="group" aria-label="Zoom controls">
+            <button class="toolbar-btn" onclick="zoomOut()" title="Zoom out">-</button>
+            <span class="toolbar-info" id="zoom-level">100%</span>
+            <button class="toolbar-btn" onclick="zoomIn()" title="Zoom in">+</button>
+            <button class="toolbar-btn" onclick="zoomReset()" title="Reset zoom">Reset</button>
+        </div>
+        <div class="menu-wrapper">
+            ${menuContent}
+        </div>
+    </div>
+    <script>
+        const vscode = acquireVsCodeApi();
+        let zoomLevel = 1;
+
+        function setZoom(level) {
+            zoomLevel = Math.min(1.6, Math.max(0.6, level));
+            const wrapper = document.querySelector('.menu-wrapper');
+            if (wrapper) {
+                wrapper.style.transform = 'scale(' + zoomLevel.toFixed(2) + ')';
+            }
+            const label = document.getElementById('zoom-level');
+            if (label) {
+                label.textContent = Math.round(zoomLevel * 100) + '%';
+            }
+        }
+
+        function previousMenu() {
+            vscode.postMessage({ command: 'previousMenu' });
+        }
+
+        function nextMenu() {
+            vscode.postMessage({ command: 'nextMenu' });
+        }
+
+        function zoomIn() {
+            setZoom(zoomLevel + 0.1);
+        }
+
+        function zoomOut() {
+            setZoom(zoomLevel - 0.1);
+        }
+
+        function zoomReset() {
+            setZoom(1);
+        }
+
+        function goToMenu() {
+            vscode.postMessage({ command: 'goToMenu' });
+        }
+
+        setZoom(1);
+    </script>
+</body>
+</html>`;
+  }
+
+  private _renderMenu(menu: PawnMenu): string {
+    const title = this._renderColorText(menu.title);
+    const columns = Math.max(1, menu.columns);
+    const rowCount = Math.max(...menu.items.map((col) => col.length), 0);
+    const rows: string[] = [];
+
+    for (let row = 0; row < rowCount; row++) {
+      const cells: string[] = [];
+      for (let col = 0; col < columns; col++) {
+        const value = menu.items[col]?.[row];
+        const cellContent = value ? this._renderColorText(value) : "&nbsp;";
+        cells.push(`<div class="menu-cell">${cellContent}</div>`);
+      }
+      const rowClass = row === 0 ? "menu-row selected" : "menu-row";
+      rows.push(`<div class="${rowClass}">${cells.join("")}</div>`);
+    }
+
+    return `
+        <div class="menu">
+            <div class="menu-title">${title}</div>
+            <div class="menu-body">
+                ${rows.join("")}
+            </div>
+        </div>
+    `;
+  }
+
+  private _renderColorText(segments: ColorSegment[]): string {
+    return segments
+      .map((segment) => {
+        if (segment.color) {
+          return `<span style="color: ${segment.color}">${this._escapeHtml(segment.text)}</span>`;
+        }
+        return this._escapeHtml(segment.text);
+      })
+      .join("");
+  }
+
+  private _escapeHtml(text: string): string {
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+  }
+
+  private _getStyles(): string {
+    return `
+            :root {
+                --chrome-bg: #1a202c;
+                --chrome-edge: #2d3748;
+                --chrome-muted: #a0aec0;
+                --chrome-text: #e2e8f0;
+                --btn-bg: #2c323d;
+                --btn-bg-hover: #3a4250;
+                --btn-border: #424b5a;
+                --page-bg: #1a202c;
+            }
+
+            @media (prefers-color-scheme: light) {
+                :root {
+                    --chrome-bg: #f7fafc;
+                    --chrome-edge: #e2e8f0;
+                    --chrome-muted: #718096;
+                    --chrome-text: #1a202c;
+                    --btn-bg: #edf2f7;
+                    --btn-bg-hover: #e2e8f0;
+                    --btn-border: #cbd5e0;
+                    --page-bg: #f7fafc;
+                }
+            }
+
+            * {
+                margin: 0;
+                padding: 0;
+                box-sizing: border-box;
+            }
+
+            body {
+                font-family: "Trebuchet MS", "Verdana", "Geneva", sans-serif;
+                background: var(--page-bg);
+                min-height: 100vh;
+                display: flex;
+                flex-direction: column;
+                color: var(--chrome-text);
+            }
+
+            .toolbar {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                background: var(--chrome-bg);
+                border-bottom: 1px solid var(--chrome-edge);
+                padding: 6px 10px;
+                position: sticky;
+                top: 0;
+                z-index: 100;
+                box-shadow: 0 8px 14px rgba(0, 0, 0, 0.25);
+            }
+
+            .toolbar-left,
+            .toolbar-right {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
+
+            .toolbar-left {
+                gap: 10px;
+            }
+
+            .toolbar-title {
+                font-size: 13px;
+                font-weight: 700;
+                letter-spacing: 0.6px;
+                text-transform: uppercase;
+                color: var(--chrome-text);
+            }
+
+            .toolbar-nav {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                padding: 4px 6px;
+                border: 1px solid var(--chrome-edge);
+                border-radius: 999px;
+                background: rgba(255, 255, 255, 0.03);
+            }
+
+            .toolbar-btn {
+                background: var(--btn-bg);
+                border: 1px solid var(--btn-border);
+                color: var(--chrome-text);
+                padding: 3px 9px;
+                cursor: pointer;
+                font-size: 10px;
+                border-radius: 999px;
+                letter-spacing: 0.2px;
+            }
+
+            .toolbar-btn:hover {
+                background: var(--btn-bg-hover);
+                color: #ffffff;
+            }
+
+            .toolbar-info {
+                color: var(--chrome-muted);
+                font-size: 11px;
+                min-width: 46px;
+                text-align: center;
+            }
+
+            .preview-container {
+                flex: 1;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                padding: 20px;
+                position: relative;
+            }
+
+            .menu-wrapper {
+                display: flex;
+                justify-content: center;
+                transform-origin: center center;
+                transition: transform 120ms ease-out;
+            }
+
+            .zoom-controls {
+                position: absolute;
+                right: 16px;
+                bottom: 16px;
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                padding: 6px 8px;
+                border-radius: 999px;
+                background: rgba(0, 0, 0, 0.35);
+                border: 1px solid var(--chrome-edge);
+                backdrop-filter: blur(6px);
+            }
+
+            .menu {
+                background: rgba(0, 0, 0, 0.85);
+                border: 1px solid #4a5568;
+                min-width: 320px;
+                max-width: 520px;
+                font-family: "Consolas", "Courier New", monospace;
+                position: relative;
+                padding-top: 10px;
+            }
+
+            .menu-title {
+                position: absolute;
+                top: -10px;
+                left: 12px;
+                padding: 0 6px;
+                font-size: 18px;
+                line-height: 20px;
+                letter-spacing: 0.4px;
+                color: #e4e2e5;
+                background: rgba(0, 0, 0, 0.85);
+            }
+
+            .menu-body {
+                padding: 10px 0 6px;
+            }
+
+            .menu-row {
+                display: flex;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+            }
+
+            .menu-row:last-child {
+                border-bottom: none;
+            }
+
+            .menu-cell {
+                flex: 1;
+                padding: 4px 10px;
+                border-right: 1px solid rgba(255, 255, 255, 0.06);
+                font-size: 12px;
+                color: #464d57;
+            }
+
+            .menu-cell:last-child {
+                border-right: none;
+            }
+
+            .menu-row.selected .menu-cell,
+            .menu-row:hover .menu-cell {
+                color: #9bb2db;
+            }
+        `;
+  }
+}

--- a/src/client/menu/types.ts
+++ b/src/client/menu/types.ts
@@ -1,0 +1,12 @@
+import * as vscode from "vscode";
+import { ColorSegment } from "../dialog/types";
+
+export interface PawnMenu {
+  menuName: string;
+  title: ColorSegment[];
+  columns: number;
+  items: ColorSegment[][][];
+  range: vscode.Range;
+  documentUri: string;
+  rawText: string;
+}

--- a/src/client/whitelistedpaths.ts
+++ b/src/client/whitelistedpaths.ts
@@ -34,7 +34,7 @@ export const InitPawnIgnore = async function () {
       },
       (error: Error) => {
         console.error(error);
-      }
+      },
     );
   } else {
     vscode.window.showInformationMessage(".pawnignore already exists, aborting task");
@@ -70,7 +70,7 @@ export const addToPawnIgnore = async function (selectedFile: vscode.Uri) {
       },
       (error: Error) => {
         console.error(error);
-      }
+      },
     );
   }
 

--- a/src/server/parser.ts
+++ b/src/server/parser.ts
@@ -28,8 +28,46 @@ interface PawnFunction {
 const pawnFuncCollection: Map<string, PawnFunction> = new Map();
 const pawnWords: Map<string, CompletionItem[]> = new Map();
 
-const commentRegex = RegExp(/\/\*/gm);
-const commentEndRegex = RegExp(/\*\//gm);
+const isLineComment = (line: string) => /^\s*\/\//.test(line);
+
+const stripBlockComments = (line: string, inBlock: boolean) => {
+  let out = "";
+  let i = 0;
+  while (i < line.length) {
+    if (inBlock) {
+      if (line.startsWith("*/", i)) {
+        out += "  ";
+        i += 2;
+        inBlock = false;
+        continue;
+      }
+      out += " ";
+      i += 1;
+      continue;
+    }
+    if (line.startsWith("/*", i)) {
+      out += "  ";
+      i += 2;
+      inBlock = true;
+      continue;
+    }
+    out += line[i];
+    i += 1;
+  }
+  return { text: out, inBlock };
+};
+
+const stripLineComment = (line: string) => {
+  const idx = line.indexOf("//");
+  if (idx === -1) return line;
+  return line.slice(0, idx) + " ".repeat(line.length - idx);
+};
+
+const sanitizeLine = (line: string, inBlock: boolean) => {
+  const stripped = stripBlockComments(line, inBlock);
+  const withLineComments = stripLineComment(stripped.text);
+  return { text: withLineComments, inBlock: stripped.inBlock };
+};
 
 export const resetAutocompletes = () => {
   pawnFuncCollection.clear();
@@ -39,138 +77,124 @@ export const parseDefine = (textDocument: TextDocument) => {
   const regexDefine = /^(\s*)#define\s+([^\s()]{1,})\s+([^\s]{1,})$/gm;
   const content = textDocument.getText();
   const splitContent = content.split("\n");
-  let excempt = 0;
-  splitContent.forEach((cont: string, index: number) => {
-    if (commentRegex.test(cont)) {
-      excempt++;
-      // This is for single line block of comment, for example: 
-      // /* Some comment text here */
-      if (commentEndRegex.test(cont)) {
-        excempt--;
+  let inBlockComment = false;
+  for (let index = 0; index < splitContent.length; index++) {
+    const cont = splitContent[index];
+    const sanitized = sanitizeLine(cont, inBlockComment);
+    inBlockComment = sanitized.inBlock;
+    if (!sanitized.text.trim() || isLineComment(sanitized.text)) continue;
+    let m;
+    do {
+      m = regexDefine.exec(sanitized.text);
+      if (m) {
+        const func = m[2];
+        const arg = m[3];
+        const newSnip: CompletionItem = {
+          label: func,
+          kind: CompletionItemKind.Text,
+          insertText: func,
+          documentation: `${func} ${arg}`,
+        };
+        const newDef: Definition = Location.create(textDocument.uri, {
+          start: { line: index, character: m.input.indexOf(func) },
+          end: {
+            line: index,
+            character: m.input.indexOf(func) + func.length,
+          },
+        });
+        const pwnFun: PawnFunction = {
+          textDocument: textDocument,
+          completion: newSnip,
+          definition: newDef,
+          type: "macrodefine",
+        };
+        const findSnip = pawnFuncCollection.get(func);
+        if (findSnip === undefined) pawnFuncCollection.set(func, pwnFun);
       }
-    } else if (commentEndRegex.test(cont)) {
-      excempt--;
-    } else if (excempt === 0) {
-      let m;
-      do {
-        m = regexDefine.exec(cont);
-        if (m) {
-          const func = m[2];
-          const arg = m[3];
-          const newSnip: CompletionItem = {
-            label: func,
-            kind: CompletionItemKind.Text,
-            insertText: func,
-            documentation: `${func} ${arg}`,
-          };
-          const newDef: Definition = Location.create(textDocument.uri, {
-            start: { line: index, character: m.input.indexOf(func) },
-            end: {
-              line: index,
-              character: m.input.indexOf(func) + func.length,
-            },
-          });
-          const pwnFun: PawnFunction = {
-            textDocument: textDocument,
-            completion: newSnip,
-            definition: newDef,
-            type: "macrodefine",
-          };
-          const findSnip = pawnFuncCollection.get(func);
-          if (findSnip === undefined) pawnFuncCollection.set(func, pwnFun);
-        }
-      } while (m);
-    }
-  });
+    } while (m);
+  }
 };
 
 export const parseFuncsDefines = (textDocument: TextDocument) => {
   const regex = /^(\s*)#define\s+([\S]{1,})\((.*?)\)/gm;
   const content = textDocument.getText();
   const splitContent = content.split("\n");
-  let excempt = 0;
-  splitContent.forEach((cont: string, index: number) => {
-    if (commentRegex.test(cont)) {
-      excempt++;
-      // This is for single line block of comment, for example: 
-      // /* Some comment text here */
-      if (commentEndRegex.test(cont)) {
-        excempt--;
-      }
-    } else if (commentEndRegex.test(cont)) {
-      excempt--;
-    } else if (excempt === 0) {
-      let m;
-      do {
-        m = regex.exec(cont);
-        if (m) {
-          const func = m[2];
-          const args = m[3];
-          let doc = "";
-          let endDoc = -1;
-          if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
-          if (endDoc !== -1) {
-            let startDoc = -1;
-            let inNum = index;
-            while (inNum >= 0) {
-              inNum--;
-              if (splitContent[inNum] === undefined) continue;
-              startDoc = splitContent[inNum].indexOf("/*");
-              if (startDoc !== -1) {
-                if (inNum === index) {
-                  doc = splitContent[index];
-                } else if (inNum < index) {
-                  while (inNum < index) {
-                    doc += splitContent[inNum] + "\n\n";
-                    inNum++;
-                  }
+  let inBlockComment = false;
+  for (let index = 0; index < splitContent.length; index++) {
+    const cont = splitContent[index];
+    const sanitized = sanitizeLine(cont, inBlockComment);
+    inBlockComment = sanitized.inBlock;
+    if (!sanitized.text.trim() || isLineComment(sanitized.text)) continue;
+    let m;
+    do {
+      m = regex.exec(sanitized.text);
+      if (m) {
+        const func = m[2];
+        const args = m[3];
+        let doc = "";
+        let endDoc = -1;
+        if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
+        if (endDoc !== -1) {
+          let startDoc = -1;
+          let inNum = index;
+          while (inNum >= 0) {
+            inNum--;
+            if (splitContent[inNum] === undefined) continue;
+            startDoc = splitContent[inNum].indexOf("/*");
+            if (startDoc !== -1) {
+              if (inNum === index) {
+                doc = splitContent[index];
+              } else if (inNum < index) {
+                while (inNum < index) {
+                  doc += splitContent[inNum] + "\n\n";
+                  inNum++;
                 }
-                break;
               }
+              break;
             }
           }
-          doc = doc.replace("/*", "").replace("*/", "").trim();
-          const newSnip: CompletionItem = {
-            label: func + "(" + args + ")",
-            kind: CompletionItemKind.Function,
-            insertText: func + "(" + args + ")",
-            documentation: doc,
-          };
-          const newDef: Definition = Location.create(textDocument.uri, {
-            start: { line: index, character: m.input.indexOf(args) },
-            end: {
-              line: index,
-              character: m.input.indexOf(args) + args.length,
-            },
-          });
-          let params: ParameterInformation[] = [];
-          if (args.trim().length > 0) {
-            params = args.split(",").map((value) => ({ label: value.trim() }));
-          } else {
-            params = [];
-          }
-          const pwnFun: PawnFunction = {
-            textDocument: textDocument,
-            definition: newDef,
-            completion: newSnip,
-            params,
-            type: "macrofunction",
-          };
-          // const indexPos = func.indexOf(':');
-          // if (indexPos !== -1) {
-          // const resOut = /:(.*)/gm.exec(func);
-          // if (resOut) func = resOut[1];
-          // }
-          const findSnip = pawnFuncCollection.get(func);
-          if (findSnip === undefined) {
-            pawnFuncCollection.set(func, pwnFun);
-          } else {
-            if (findSnip.type === "macrodefine") pawnFuncCollection.set(func, pwnFun);
-          }
         }
-      } while (m);
-    }
-  });
+        doc = doc.replace("/*", "").replace("*/", "").trim();
+        const newSnip: CompletionItem = {
+          label: func + "(" + args + ")",
+          kind: CompletionItemKind.Function,
+          insertText: func + "(" + args + ")",
+          documentation: doc,
+        };
+        const newDef: Definition = Location.create(textDocument.uri, {
+          start: { line: index, character: m.input.indexOf(args) },
+          end: {
+            line: index,
+            character: m.input.indexOf(args) + args.length,
+          },
+        });
+        let params: ParameterInformation[] = [];
+        if (args.trim().length > 0) {
+          params = args.split(",").map((value) => ({ label: value.trim() }));
+        } else {
+          params = [];
+        }
+        const pwnFun: PawnFunction = {
+          textDocument: textDocument,
+          definition: newDef,
+          completion: newSnip,
+          params,
+          type: "macrofunction",
+        };
+        // const indexPos = func.indexOf(':');
+        // if (indexPos !== -1) {
+        // const resOut = /:(.*)/gm.exec(func);
+        // if (resOut) func = resOut[1];
+        // }
+        const findSnip = pawnFuncCollection.get(func);
+        if (findSnip === undefined) {
+          pawnFuncCollection.set(func, pwnFun);
+        } else {
+          if (findSnip.type === "macrodefine") pawnFuncCollection.set(func, pwnFun);
+        }
+      }
+    } while (m);
+  }
 };
 
 export const parseCustomSnip = (textDocument: TextDocument) => {
@@ -179,472 +203,437 @@ export const parseCustomSnip = (textDocument: TextDocument) => {
   const content = textDocument.getText();
   const splitContent = content.split("\n");
 
-  let excempt = 0;
-  splitContent.forEach((cont: string, index: number) => {
-    if (commentRegex.test(cont)) {
-      excempt++;
-      // This is for single line block of comment, for example: 
-      // /* Some comment text here */
-      if (commentEndRegex.test(cont)) {
-        excempt--;
+  let inBlockComment = false;
+  for (let index = 0; index < splitContent.length; index++) {
+    const cont = splitContent[index];
+    const sanitized = sanitizeLine(cont, inBlockComment);
+    inBlockComment = sanitized.inBlock;
+    if (!sanitized.text.trim() || isLineComment(sanitized.text)) continue;
+    let fisrtReg;
+    do {
+      fisrtReg = regexDefine.exec(sanitized.text);
+      if (fisrtReg) {
+        const func = fisrtReg[1];
+        const args = fisrtReg[2];
+        const newSnip: CompletionItem = {
+          label: func,
+          kind: CompletionItemKind.Function,
+          insertText: args,
+          documentation: `${func} ${args}`,
+        };
+        const newDef: Definition = Location.create(textDocument.uri, {
+          start: { line: index, character: fisrtReg.input.indexOf(func) },
+          end: {
+            line: index,
+            character: fisrtReg.input.indexOf(func) + func.length,
+          },
+        });
+        const pwnFun: PawnFunction = {
+          textDocument: textDocument,
+          completion: newSnip,
+          definition: newDef,
+          type: "customsnip",
+        };
+        pawnFuncCollection.set(func, pwnFun);
       }
-    } else if (commentEndRegex.test(cont)) {
-      excempt--;
-    } else if (excempt === 0) {
-      let fisrtReg;
-      do {
-        fisrtReg = regexDefine.exec(cont);
-        if (fisrtReg) {
-          const func = fisrtReg[1];
-          const args = fisrtReg[2];
-          const newSnip: CompletionItem = {
-            label: func,
-            kind: CompletionItemKind.Function,
-            insertText: args,
-            documentation: `${func} ${args}`,
-          };
-          const newDef: Definition = Location.create(textDocument.uri, {
-            start: { line: index, character: fisrtReg.input.indexOf(func) },
-            end: {
-              line: index,
-              character: fisrtReg.input.indexOf(func) + func.length,
-            },
-          });
-          const pwnFun: PawnFunction = {
-            textDocument: textDocument,
-            completion: newSnip,
-            definition: newDef,
-            type: "customsnip",
-          };
-          pawnFuncCollection.set(func, pwnFun);
-        }
-      } while (fisrtReg);
-      let m;
-      do {
-        m = regexFunction.exec(cont);
-        if (m) {
-          const func = m[1];
-          const args = m[2];
-          let doc = "";
-          let endDoc = -1;
-          if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
-          if (endDoc !== -1) {
-            let startDoc = -1;
-            let inNum = index;
-            while (inNum >= 0) {
-              inNum--;
-              if (splitContent[inNum] === undefined) continue;
-              startDoc = splitContent[inNum].indexOf("/*");
-              if (startDoc !== -1) {
-                if (inNum === index) {
-                  doc = splitContent[index];
-                } else if (inNum < index) {
-                  while (inNum < index) {
-                    doc += splitContent[inNum] + "\n\n";
-                    inNum++;
-                  }
+    } while (fisrtReg);
+    let m;
+    do {
+      m = regexFunction.exec(sanitized.text);
+      if (m) {
+        const func = m[1];
+        const args = m[2];
+        let doc = "";
+        let endDoc = -1;
+        if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
+        if (endDoc !== -1) {
+          let startDoc = -1;
+          let inNum = index;
+          while (inNum >= 0) {
+            inNum--;
+            if (splitContent[inNum] === undefined) continue;
+            startDoc = splitContent[inNum].indexOf("/*");
+            if (startDoc !== -1) {
+              if (inNum === index) {
+                doc = splitContent[index];
+              } else if (inNum < index) {
+                while (inNum < index) {
+                  doc += splitContent[inNum] + "\n\n";
+                  inNum++;
                 }
-                break;
               }
+              break;
             }
           }
-          doc = doc.replace("/*", "").replace("*/", "").trim();
-          const newSnip: CompletionItem = {
-            label: func + "(" + args + ")",
-            kind: CompletionItemKind.Function,
-            insertText: func + "(" + args + ")",
-            documentation: doc,
-          };
-          const newDef: Definition = Location.create(textDocument.uri, {
-            start: { line: index, character: m.input.indexOf(func) },
-            end: {
-              line: index,
-              character: m.input.indexOf(func) + func.length,
-            },
-          });
-          let params: ParameterInformation[] = [];
-          if (args.trim().length > 0) {
-            params = args.split(",").map((value) => ({ label: value.trim() }));
-          } else {
-            params = [];
-          }
-          const pwnFun: PawnFunction = {
-            textDocument: textDocument,
-            definition: newDef,
-            completion: newSnip,
-            params,
-            type: "customsnip",
-          };
-          // const indexPos = func.indexOf(':');
-          // if (indexPos !== -1) {
-          // const resOut = /:(.*)/gm.exec(func);
-          // if (resOut) func = resOut[1];
-          // }
-          pawnFuncCollection.set(func, pwnFun);
         }
-      } while (m);
-    }
-  });
+        doc = doc.replace("/*", "").replace("*/", "").trim();
+        const newSnip: CompletionItem = {
+          label: func + "(" + args + ")",
+          kind: CompletionItemKind.Function,
+          insertText: func + "(" + args + ")",
+          documentation: doc,
+        };
+        const newDef: Definition = Location.create(textDocument.uri, {
+          start: { line: index, character: m.input.indexOf(func) },
+          end: {
+            line: index,
+            character: m.input.indexOf(func) + func.length,
+          },
+        });
+        let params: ParameterInformation[] = [];
+        if (args.trim().length > 0) {
+          params = args.split(",").map((value) => ({ label: value.trim() }));
+        } else {
+          params = [];
+        }
+        const pwnFun: PawnFunction = {
+          textDocument: textDocument,
+          definition: newDef,
+          completion: newSnip,
+          params,
+          type: "customsnip",
+        };
+        // const indexPos = func.indexOf(':');
+        // if (indexPos !== -1) {
+        // const resOut = /:(.*)/gm.exec(func);
+        // if (resOut) func = resOut[1];
+        // }
+        pawnFuncCollection.set(func, pwnFun);
+      }
+    } while (m);
+  }
 };
 
 export const parseFuncs = (textDocument: TextDocument) => {
   const regex = /^(\s*)(public|stock|function|func)\s+([\S]{1,})\((.*?)\)/gm;
   const content = textDocument.getText();
   const splitContent = content.split("\n");
-  let excempt = 0;
-  splitContent.forEach((cont: string, index: number) => {
-    if (commentRegex.test(cont)) {
-      excempt++;
-      // This is for single line block of comment, for example: 
-      // /* Some comment text here */
-      if (commentEndRegex.test(cont)) {
-        excempt--;
-      }
-    } else if (commentEndRegex.test(cont)) {
-      excempt--;
-    } else if (excempt === 0) {
-      let m;
-      do {
-        m = regex.exec(cont);
-        if (m) {
-          const func = m[3];
-          const args = m[4];
-          let doc = "";
-          let endDoc = -1;
-          if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
-          if (endDoc !== -1) {
-            let startDoc = -1;
-            let inNum = index;
-            while (inNum >= 0) {
-              inNum--;
-              if (splitContent[inNum] === undefined) continue;
-              startDoc = splitContent[inNum].indexOf("/*");
-              if (startDoc !== -1) {
-                if (inNum === index) {
-                  doc = splitContent[index];
-                } else if (inNum < index) {
-                  while (inNum < index) {
-                    doc += splitContent[inNum] + "\n\n";
-                    inNum++;
-                  }
+  let inBlockComment = false;
+  for (let index = 0; index < splitContent.length; index++) {
+    const cont = splitContent[index];
+    const sanitized = sanitizeLine(cont, inBlockComment);
+    inBlockComment = sanitized.inBlock;
+    if (!sanitized.text.trim() || isLineComment(sanitized.text)) continue;
+    let m;
+    do {
+      m = regex.exec(sanitized.text);
+      if (m) {
+        const func = m[3];
+        const args = m[4];
+        let doc = "";
+        let endDoc = -1;
+        if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
+        if (endDoc !== -1) {
+          let startDoc = -1;
+          let inNum = index;
+          while (inNum >= 0) {
+            inNum--;
+            if (splitContent[inNum] === undefined) continue;
+            startDoc = splitContent[inNum].indexOf("/*");
+            if (startDoc !== -1) {
+              if (inNum === index) {
+                doc = splitContent[index];
+              } else if (inNum < index) {
+                while (inNum < index) {
+                  doc += splitContent[inNum] + "\n\n";
+                  inNum++;
                 }
-                break;
               }
+              break;
             }
           }
-          doc = doc.replace("/*", "").replace("*/", "").trim();
-          const noTagFunc = func.replace(/^[^:]*:/gm, "");
-          const newSnip: CompletionItem = {
-            label: func + "(" + args + ")",
-            kind: CompletionItemKind.Function,
-            insertText: noTagFunc,
-            documentation: doc,
-          };
-          const newDef: Definition = Location.create(textDocument.uri, {
-            start: { line: index, character: m.input.indexOf(noTagFunc) },
-            end: {
-              line: index,
-              character: m.input.indexOf(noTagFunc) + noTagFunc.length,
-            },
-          });
-          let params: ParameterInformation[] = [];
-          if (args.trim().length > 0) {
-            params = args.split(",").map((value) => ({ label: value.trim() }));
-          } else {
-            params = [];
-          }
-          const pwnFun: PawnFunction = {
-            textDocument: textDocument,
-            definition: newDef,
-            completion: newSnip,
-            params,
-            type: "function",
-          };
-
-          const findSnip = pawnFuncCollection.get(noTagFunc);
-          if (findSnip === undefined) {
-            pawnFuncCollection.set(noTagFunc, pwnFun);
-          } else {
-            if (
-              findSnip.type === "macrofunction" ||
-              findSnip.type === "macrodefine" ||
-              findSnip.type === "customsnip" ||
-              findSnip.type === "forward"
-            )
-              pawnFuncCollection.set(noTagFunc, pwnFun);
-          }
         }
-      } while (m);
-    }
-  });
+        doc = doc.replace("/*", "").replace("*/", "").trim();
+        const noTagFunc = func.replace(/^[^:]*:/gm, "");
+        const newSnip: CompletionItem = {
+          label: func + "(" + args + ")",
+          kind: CompletionItemKind.Function,
+          insertText: noTagFunc,
+          documentation: doc,
+        };
+        const newDef: Definition = Location.create(textDocument.uri, {
+          start: { line: index, character: m.input.indexOf(noTagFunc) },
+          end: {
+            line: index,
+            character: m.input.indexOf(noTagFunc) + noTagFunc.length,
+          },
+        });
+        let params: ParameterInformation[] = [];
+        if (args.trim().length > 0) {
+          params = args.split(",").map((value) => ({ label: value.trim() }));
+        } else {
+          params = [];
+        }
+        const pwnFun: PawnFunction = {
+          textDocument: textDocument,
+          definition: newDef,
+          completion: newSnip,
+          params,
+          type: "function",
+        };
+
+        const findSnip = pawnFuncCollection.get(noTagFunc);
+        if (findSnip === undefined) {
+          pawnFuncCollection.set(noTagFunc, pwnFun);
+        } else {
+          if (
+            findSnip.type === "macrofunction" ||
+            findSnip.type === "macrodefine" ||
+            findSnip.type === "customsnip" ||
+            findSnip.type === "forward"
+          )
+            pawnFuncCollection.set(noTagFunc, pwnFun);
+        }
+      }
+    } while (m);
+  }
 };
 
 export const parseForward = (textDocument: TextDocument) => {
   const regex = /^(\s*)(forward)\s+([\S]{1,})\((.*?)\)/gm;
   const content = textDocument.getText();
   const splitContent = content.split("\n");
-  let excempt = 0;
-  splitContent.forEach((cont: string, index: number) => {
-    if (commentRegex.test(cont)) {
-      excempt++;
-      // This is for single line block of comment, for example: 
-      // /* Some comment text here */
-      if (commentEndRegex.test(cont)) {
-        excempt--;
-      }
-    } else if (commentEndRegex.test(cont)) {
-      excempt--;
-    } else if (excempt === 0) {
-      let m;
-      do {
-        m = regex.exec(cont);
-        if (m) {
-          const func = m[3];
-          const args = m[4];
-          let doc = "";
-          let endDoc = -1;
-          if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
-          if (endDoc !== -1) {
-            let startDoc = -1;
-            let inNum = index;
-            while (inNum >= 0) {
-              inNum--;
-              if (splitContent[inNum] === undefined) continue;
-              startDoc = splitContent[inNum].indexOf("/*");
-              if (startDoc !== -1) {
-                if (inNum === index) {
-                  doc = splitContent[index];
-                } else if (inNum < index) {
-                  while (inNum < index) {
-                    doc += splitContent[inNum] + "\n\n";
-                    inNum++;
-                  }
+  let inBlockComment = false;
+  for (let index = 0; index < splitContent.length; index++) {
+    const cont = splitContent[index];
+    const sanitized = sanitizeLine(cont, inBlockComment);
+    inBlockComment = sanitized.inBlock;
+    if (!sanitized.text.trim() || isLineComment(sanitized.text)) continue;
+    let m;
+    do {
+      m = regex.exec(sanitized.text);
+      if (m) {
+        const func = m[3];
+        const args = m[4];
+        let doc = "";
+        let endDoc = -1;
+        if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
+        if (endDoc !== -1) {
+          let startDoc = -1;
+          let inNum = index;
+          while (inNum >= 0) {
+            inNum--;
+            if (splitContent[inNum] === undefined) continue;
+            startDoc = splitContent[inNum].indexOf("/*");
+            if (startDoc !== -1) {
+              if (inNum === index) {
+                doc = splitContent[index];
+              } else if (inNum < index) {
+                while (inNum < index) {
+                  doc += splitContent[inNum] + "\n\n";
+                  inNum++;
                 }
-                break;
               }
+              break;
             }
           }
-          doc = doc.replace("/*", "").replace("*/", "").trim();
-          const noTagFunc = func.replace(/^[^:]*:/gm, "");
-          const newSnip: CompletionItem = {
-            label: func + "(" + args + ")",
-            kind: CompletionItemKind.Function,
-            insertText: func + "(" + args + ")",
-            documentation: doc,
-          };
-          const newDef: Definition = Location.create(textDocument.uri, {
-            start: { line: index, character: m.input.indexOf(noTagFunc) },
-            end: {
-              line: index,
-              character: m.input.indexOf(noTagFunc) + noTagFunc.length,
-            },
-          });
-          let params: ParameterInformation[] = [];
-          if (args.trim().length > 0) {
-            params = args.split(",").map((value) => ({ label: value.trim() }));
-          } else {
-            params = [];
-          }
-          const pwnFun: PawnFunction = {
-            textDocument: textDocument,
-            definition: newDef,
-            completion: newSnip,
-            params,
-            type: "forward",
-          };
-
-          const findSnip = pawnFuncCollection.get(noTagFunc);
-          if (findSnip === undefined) {
-            pawnFuncCollection.set(noTagFunc, pwnFun);
-          } else {
-            if (findSnip.type === "macrofunction" || findSnip.type === "macrodefine" || findSnip.type === "customsnip")
-              pawnFuncCollection.set(noTagFunc, pwnFun);
-          }
         }
-      } while (m);
-    }
-  });
+        doc = doc.replace("/*", "").replace("*/", "").trim();
+        const noTagFunc = func.replace(/^[^:]*:/gm, "");
+        const newSnip: CompletionItem = {
+          label: func + "(" + args + ")",
+          kind: CompletionItemKind.Function,
+          insertText: func + "(" + args + ")",
+          documentation: doc,
+        };
+        const newDef: Definition = Location.create(textDocument.uri, {
+          start: { line: index, character: m.input.indexOf(noTagFunc) },
+          end: {
+            line: index,
+            character: m.input.indexOf(noTagFunc) + noTagFunc.length,
+          },
+        });
+        let params: ParameterInformation[] = [];
+        if (args.trim().length > 0) {
+          params = args.split(",").map((value) => ({ label: value.trim() }));
+        } else {
+          params = [];
+        }
+        const pwnFun: PawnFunction = {
+          textDocument: textDocument,
+          definition: newDef,
+          completion: newSnip,
+          params,
+          type: "forward",
+        };
+
+        const findSnip = pawnFuncCollection.get(noTagFunc);
+        if (findSnip === undefined) {
+          pawnFuncCollection.set(noTagFunc, pwnFun);
+        } else {
+          if (findSnip.type === "macrofunction" || findSnip.type === "macrodefine" || findSnip.type === "customsnip")
+            pawnFuncCollection.set(noTagFunc, pwnFun);
+        }
+      }
+    } while (m);
+  }
 };
 
 export const parseFuncsNonPrefix = (textDocument: TextDocument) => {
   const regex = /^([\S]{1,})\((.*?)\)/gm;
   const content = textDocument.getText();
   const splitContent = content.split("\n");
-  let excempt = 0;
-  splitContent.forEach((cont: string, index: number) => {
-    if (commentRegex.test(cont)) {
-      excempt++;
-      // This is for single line block of comment, for example: 
-      // /* Some comment text here */
-      if (commentEndRegex.test(cont)) {
-        excempt--;
-      }
-    } else if (commentEndRegex.test(cont)) {
-      excempt--;
-    } else if (excempt === 0) {
-      let m;
-      do {
-        m = regex.exec(cont);
-        if (m) {
-          const func = m[1];
-          const args = m[2];
-          let doc = "";
-          let endDoc = -1;
-          if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
-          if (endDoc !== -1) {
-            let startDoc = -1;
-            let inNum = index;
-            while (inNum >= 0) {
-              inNum--;
-              if (splitContent[inNum] === undefined) continue;
-              startDoc = splitContent[inNum].indexOf("/*");
-              if (startDoc !== -1) {
-                if (inNum === index) {
-                  doc = splitContent[index];
-                } else if (inNum < index) {
-                  while (inNum < index) {
-                    doc += splitContent[inNum] + "\n\n";
-                    inNum++;
-                  }
+  let inBlockComment = false;
+  for (let index = 0; index < splitContent.length; index++) {
+    const cont = splitContent[index];
+    const sanitized = sanitizeLine(cont, inBlockComment);
+    inBlockComment = sanitized.inBlock;
+    if (!sanitized.text.trim() || isLineComment(sanitized.text)) continue;
+    let m;
+    do {
+      m = regex.exec(sanitized.text);
+      if (m) {
+        const func = m[1];
+        const args = m[2];
+        let doc = "";
+        let endDoc = -1;
+        if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
+        if (endDoc !== -1) {
+          let startDoc = -1;
+          let inNum = index;
+          while (inNum >= 0) {
+            inNum--;
+            if (splitContent[inNum] === undefined) continue;
+            startDoc = splitContent[inNum].indexOf("/*");
+            if (startDoc !== -1) {
+              if (inNum === index) {
+                doc = splitContent[index];
+              } else if (inNum < index) {
+                while (inNum < index) {
+                  doc += splitContent[inNum] + "\n\n";
+                  inNum++;
                 }
-                break;
               }
+              break;
             }
           }
-          doc = doc.replace("/*", "").replace("*/", "").trim();
-          const noTagFunc = func.replace(/^[^:]*:/gm, "");
-          const newSnip: CompletionItem = {
-            label: func + "(" + args + ")",
-            kind: CompletionItemKind.Function,
-            insertText: noTagFunc,
-            documentation: doc,
-          };
-          const newDef: Definition = Location.create(textDocument.uri, {
-            start: { line: index, character: m.input.indexOf(noTagFunc) },
-            end: {
-              line: index,
-              character: m.input.indexOf(noTagFunc) + noTagFunc.length,
-            },
-          });
-          let params: ParameterInformation[] = [];
-          if (args.trim().length > 0) {
-            params = args.split(",").map((value) => ({ label: value.trim() }));
-          } else {
-            params = [];
-          }
-          const pwnFun: PawnFunction = {
-            textDocument: textDocument,
-            definition: newDef,
-            completion: newSnip,
-            params,
-            type: "function",
-          };
-          // const indexPos = func.indexOf(':');
-          // if (indexPos !== -1) {
-          // const resOut = /:(.*)/gm.exec(func);
-          // if (resOut) func = resOut[1];
-          // }
-          const findSnip = pawnFuncCollection.get(noTagFunc);
-          if (findSnip === undefined) {
-            pawnFuncCollection.set(noTagFunc, pwnFun);
-          } else {
-            if (findSnip.type === "macrofunction" || findSnip.type === "macrodefine" || findSnip.type === "customsnip")
-              pawnFuncCollection.set(noTagFunc, pwnFun);
-          }
         }
-      } while (m);
-    }
-  });
+        doc = doc.replace("/*", "").replace("*/", "").trim();
+        const noTagFunc = func.replace(/^[^:]*:/gm, "");
+        const newSnip: CompletionItem = {
+          label: func + "(" + args + ")",
+          kind: CompletionItemKind.Function,
+          insertText: noTagFunc,
+          documentation: doc,
+        };
+        const newDef: Definition = Location.create(textDocument.uri, {
+          start: { line: index, character: m.input.indexOf(noTagFunc) },
+          end: {
+            line: index,
+            character: m.input.indexOf(noTagFunc) + noTagFunc.length,
+          },
+        });
+        let params: ParameterInformation[] = [];
+        if (args.trim().length > 0) {
+          params = args.split(",").map((value) => ({ label: value.trim() }));
+        } else {
+          params = [];
+        }
+        const pwnFun: PawnFunction = {
+          textDocument: textDocument,
+          definition: newDef,
+          completion: newSnip,
+          params,
+          type: "function",
+        };
+        // const indexPos = func.indexOf(':');
+        // if (indexPos !== -1) {
+        // const resOut = /:(.*)/gm.exec(func);
+        // if (resOut) func = resOut[1];
+        // }
+        const findSnip = pawnFuncCollection.get(noTagFunc);
+        if (findSnip === undefined) {
+          pawnFuncCollection.set(noTagFunc, pwnFun);
+        } else {
+          if (findSnip.type === "macrofunction" || findSnip.type === "macrodefine" || findSnip.type === "customsnip")
+            pawnFuncCollection.set(noTagFunc, pwnFun);
+        }
+      }
+    } while (m);
+  }
 };
 
 export const parseNatives = (textDocument: TextDocument) => {
   const regex = /^(\s*)(native)\s([\S]{1,})\((.*?)\)/gm;
   const content = textDocument.getText();
   const splitContent = content.split("\n");
-  let excempt = 0;
-  splitContent.forEach((cont: string, index: number) => {
-    if (commentRegex.test(cont)) {
-      excempt++;
-      // This is for single line block of comment, for example: 
-      // /* Some comment text here */
-      if (commentEndRegex.test(cont)) {
-        excempt--;
-      }
-    } else if (commentEndRegex.test(cont)) {
-      excempt--;
-    } else if (excempt === 0) {
-      let m;
-      do {
-        m = regex.exec(cont);
-        if (m) {
-          const func = m[3];
-          const args = m[4];
-          let doc = "";
-          let endDoc = -1;
-          if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
-          if (endDoc !== -1) {
-            let startDoc = -1;
-            let inNum = index;
-            while (inNum >= 0) {
-              inNum--;
-              if (splitContent[inNum] === undefined) continue;
-              startDoc = splitContent[inNum].indexOf("/*");
-              if (startDoc !== -1) {
-                if (inNum === index) {
-                  doc = splitContent[index];
-                } else if (inNum < index) {
-                  while (inNum < index) {
-                    doc += splitContent[inNum] + "\n\n";
-                    inNum++;
-                  }
+  let inBlockComment = false;
+  for (let index = 0; index < splitContent.length; index++) {
+    const cont = splitContent[index];
+    const sanitized = sanitizeLine(cont, inBlockComment);
+    inBlockComment = sanitized.inBlock;
+    if (!sanitized.text.trim() || isLineComment(sanitized.text)) continue;
+    let m;
+    do {
+      m = regex.exec(sanitized.text);
+      if (m) {
+        const func = m[3];
+        const args = m[4];
+        let doc = "";
+        let endDoc = -1;
+        if (splitContent[index - 1] !== undefined) endDoc = splitContent[index - 1].indexOf("*/");
+        if (endDoc !== -1) {
+          let startDoc = -1;
+          let inNum = index;
+          while (inNum >= 0) {
+            inNum--;
+            if (splitContent[inNum] === undefined) continue;
+            startDoc = splitContent[inNum].indexOf("/*");
+            if (startDoc !== -1) {
+              if (inNum === index) {
+                doc = splitContent[index];
+              } else if (inNum < index) {
+                while (inNum < index) {
+                  doc += splitContent[inNum] + "\n\n";
+                  inNum++;
                 }
-                break;
               }
+              break;
             }
           }
-          doc = doc.replace("/*", "").replace("*/", "").trim();
-          const noTagFunc = func.replace(/^[^:]*:/gm, "");
-          const newSnip: CompletionItem = {
-            label: func + "(" + args + ")",
-            kind: CompletionItemKind.Function,
-            insertText: noTagFunc,
-            documentation: doc,
-          };
-          const newDef: Definition = Location.create(textDocument.uri, {
-            start: { line: index, character: m.input.indexOf(noTagFunc) },
-            end: {
-              line: index,
-              character: m.input.indexOf(noTagFunc) + noTagFunc.length,
-            },
-          });
-          let params: ParameterInformation[] = [];
-          if (args.trim().length > 0) {
-            params = args.split(",").map((value) => ({ label: value.trim() }));
-          } else {
-            params = [];
-          }
-          const pwnFun: PawnFunction = {
-            textDocument: textDocument,
-            definition: newDef,
-            completion: newSnip,
-            params,
-            type: "native",
-          };
-          // const indexPos = func.indexOf(':');
-          // if (indexPos !== -1) {
-          // const resOut = /:(.*)/gm.exec(func);
-          // if (resOut) func = resOut[1];
-          // }
-          const findSnip = pawnFuncCollection.get(noTagFunc);
-          if (findSnip === undefined) {
-            pawnFuncCollection.set(noTagFunc, pwnFun);
-          } else {
-            if (findSnip.type !== "customsnip") pawnFuncCollection.set(noTagFunc, pwnFun);
-          }
         }
-      } while (m);
-    }
-  });
+        doc = doc.replace("/*", "").replace("*/", "").trim();
+        const noTagFunc = func.replace(/^[^:]*:/gm, "");
+        const newSnip: CompletionItem = {
+          label: func + "(" + args + ")",
+          kind: CompletionItemKind.Function,
+          insertText: noTagFunc,
+          documentation: doc,
+        };
+        const newDef: Definition = Location.create(textDocument.uri, {
+          start: { line: index, character: m.input.indexOf(noTagFunc) },
+          end: {
+            line: index,
+            character: m.input.indexOf(noTagFunc) + noTagFunc.length,
+          },
+        });
+        let params: ParameterInformation[] = [];
+        if (args.trim().length > 0) {
+          params = args.split(",").map((value) => ({ label: value.trim() }));
+        } else {
+          params = [];
+        }
+        const pwnFun: PawnFunction = {
+          textDocument: textDocument,
+          definition: newDef,
+          completion: newSnip,
+          params,
+          type: "native",
+        };
+        // const indexPos = func.indexOf(':');
+        // if (indexPos !== -1) {
+        // const resOut = /:(.*)/gm.exec(func);
+        // if (resOut) func = resOut[1];
+        // }
+        const findSnip = pawnFuncCollection.get(noTagFunc);
+        if (findSnip === undefined) {
+          pawnFuncCollection.set(noTagFunc, pwnFun);
+        } else {
+          if (findSnip.type !== "customsnip") pawnFuncCollection.set(noTagFunc, pwnFun);
+        }
+      }
+    } while (m);
+  }
 };
 
 export const parseWords = (textDocument: TextDocument) => {
@@ -653,27 +642,19 @@ export const parseWords = (textDocument: TextDocument) => {
   const splitContent = content.split("\n");
   const words: string[] = [];
   const wordCompletion: CompletionItem[] = [];
-  let excempt = 0;
-  splitContent.forEach((cont: string) => {
-    if (commentRegex.test(cont)) {
-      excempt++;
-      // This is for single line block of comment, for example: 
-      // /* Some comment text here */
-      if (commentEndRegex.test(cont)) {
-        excempt--;
+  let inBlockComment = false;
+  for (const cont of splitContent) {
+    const sanitized = sanitizeLine(cont, inBlockComment);
+    inBlockComment = sanitized.inBlock;
+    if (!sanitized.text.trim() || isLineComment(sanitized.text)) continue;
+    let m;
+    do {
+      m = regex.exec(sanitized.text);
+      if (m) {
+        if (words.indexOf(m[0]) === -1) words.push(m[0]);
       }
-    } else if (commentEndRegex.test(cont)) {
-      excempt--;
-    } else if (excempt === 0 && !RegExp(/^\/\//gm).test(cont.trim())) {
-      let m;
-      do {
-        m = regex.exec(cont);
-        if (m) {
-          if (words.indexOf(m[0]) === -1) words.push(m[0]);
-        }
-      } while (m);
-    }
-  });
+    } while (m);
+  }
   for (const key in words) {
     const element = words[key];
     const newSnip: CompletionItem = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
+  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz"
   integrity sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==
   dependencies:
     ajv "^6.12.4"
@@ -19,7 +19,7 @@
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
+  resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz"
   integrity sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
@@ -28,30 +28,30 @@
 
 "@humanwhocodes/module-importer@^1.0.1":
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  resolved "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz"
   integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
   integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
   dependencies:
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
 "@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
@@ -59,27 +59,27 @@
 
 "@types/json-schema@^7.0.9":
   version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
 "@types/node@^18.7.6":
   version "18.11.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
+  resolved "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
 "@types/semver@^7.3.12":
   version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
 "@types/vscode@^1.70.0":
   version "1.74.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.74.0.tgz#4adc21b4e7f527b893de3418c21a91f1e503bdcd"
+  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz"
   integrity sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==
 
 "@typescript-eslint/eslint-plugin@^5.33.1":
   version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz#54f8368d080eb384a455f60c2ee044e948a8ce67"
+  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz"
   integrity sha512-SVLafp0NXpoJY7ut6VFVUU9I+YeFsDzeQwtK0WZ+xbRN3mtxJ08je+6Oi2N89qDn087COdO0u3blKZNv9VetRQ==
   dependencies:
     "@typescript-eslint/scope-manager" "5.48.0"
@@ -92,9 +92,9 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.33.1":
+"@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@^5.33.1":
   version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.48.0.tgz#02803355b23884a83e543755349809a50b7ed9ba"
+  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.0.tgz"
   integrity sha512-1mxNA8qfgxX8kBvRDIHEzrRGrKHQfQlbW6iHyfHYS0Q4X1af+S6mkLNtgCOsGVl8+/LUPrqdHMssAemkrQ01qg==
   dependencies:
     "@typescript-eslint/scope-manager" "5.48.0"
@@ -104,7 +104,7 @@
 
 "@typescript-eslint/scope-manager@5.48.0":
   version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz#607731cb0957fbc52fd754fd79507d1b6659cecf"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.0.tgz"
   integrity sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==
   dependencies:
     "@typescript-eslint/types" "5.48.0"
@@ -112,7 +112,7 @@
 
 "@typescript-eslint/type-utils@5.48.0":
   version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz#40496dccfdc2daa14a565f8be80ad1ae3882d6d6"
+  resolved "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.0.tgz"
   integrity sha512-vbtPO5sJyFjtHkGlGK4Sthmta0Bbls4Onv0bEqOGm7hP9h8UpRsHJwsrCiWtCUndTRNQO/qe6Ijz9rnT/DB+7g==
   dependencies:
     "@typescript-eslint/typescript-estree" "5.48.0"
@@ -122,12 +122,12 @@
 
 "@typescript-eslint/types@5.48.0":
   version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.48.0.tgz#d725da8dfcff320aab2ac6f65c97b0df30058449"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.0.tgz"
   integrity sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==
 
 "@typescript-eslint/typescript-estree@5.48.0":
   version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz#a7f04bccb001003405bb5452d43953a382c2fac2"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.0.tgz"
   integrity sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==
   dependencies:
     "@typescript-eslint/types" "5.48.0"
@@ -140,7 +140,7 @@
 
 "@typescript-eslint/utils@5.48.0":
   version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.48.0.tgz#eee926af2733f7156ad8d15e51791e42ce300273"
+  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.0.tgz"
   integrity sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
@@ -154,7 +154,7 @@
 
 "@typescript-eslint/visitor-keys@5.48.0":
   version "5.48.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz#4446d5e7f6cadde7140390c0e284c8702d944904"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.0.tgz"
   integrity sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==
   dependencies:
     "@typescript-eslint/types" "5.48.0"
@@ -162,17 +162,17 @@
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.8.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.8.0:
   version "8.8.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
@@ -182,39 +182,39 @@ ajv@^6.10.0, ajv@^6.12.4:
 
 ansi-regex@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^4.1.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
 
 argparse@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 array-union@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 astyle@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astyle/-/astyle-2.0.0.tgz#79bf1475b4a3e9778823dc2fadf1709fdc143a74"
+  resolved "https://registry.npmjs.org/astyle/-/astyle-2.0.0.tgz"
   integrity sha512-qmtKy9S4k2xjHIQei6DjLtHy1I7Nu3dZFACFSMMHBypxn2UuH6M9VHwJ4/3WWtUmexs7j1cwfC2QhsGLmLyu8A==
 
 balanced-match@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
   integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   dependencies:
     balanced-match "^1.0.0"
@@ -222,19 +222,19 @@ brace-expansion@^1.1.7:
 
 braces@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
 
 callsites@^3.0.0:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 chalk@^4.0.0:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
@@ -242,24 +242,24 @@ chalk@^4.0.0:
 
 color-convert@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
 
 color-name@~1.1.4:
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 cross-spawn@^7.0.2:
   version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   dependencies:
     path-key "^3.1.0"
@@ -268,38 +268,38 @@ cross-spawn@^7.0.2:
 
 debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
 deep-is@^0.1.3:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  resolved "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz"
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
 
 doctrine@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  resolved "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz"
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 eslint-scope@^5.1.1:
   version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
     esrecurse "^4.3.0"
@@ -307,7 +307,7 @@ eslint-scope@^5.1.1:
 
 eslint-scope@^7.1.1:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz"
   integrity sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==
   dependencies:
     esrecurse "^4.3.0"
@@ -315,24 +315,24 @@ eslint-scope@^7.1.1:
 
 eslint-utils@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  resolved "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz"
   integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   dependencies:
     eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint-visitor-keys@^3.3.0:
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@^8.22.0:
+eslint@*, "eslint@^6.0.0 || ^7.0.0 || ^8.0.0", eslint@^8.22.0, eslint@>=5:
   version "8.31.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.31.0.tgz#75028e77cbcff102a9feae1d718135931532d524"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz"
   integrity sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==
   dependencies:
     "@eslint/eslintrc" "^1.4.1"
@@ -377,7 +377,7 @@ eslint@^8.22.0:
 
 espree@^9.4.0:
   version "9.4.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
+  resolved "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz"
   integrity sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==
   dependencies:
     acorn "^8.8.0"
@@ -386,41 +386,41 @@ espree@^9.4.0:
 
 esquery@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  resolved "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz"
   integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
 esrecurse@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  resolved "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
 
 estraverse@^4.1.1:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.2.9:
   version "3.2.12"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
@@ -431,38 +431,38 @@ fast-glob@^3.2.9:
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-levenshtein@^2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
   version "1.15.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
+  resolved "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz"
   integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
 
 fill-range@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
 
 find-up@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
   dependencies:
     locate-path "^6.0.0"
@@ -470,7 +470,7 @@ find-up@^5.0.0:
 
 flat-cache@^3.0.4:
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz"
   integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
   dependencies:
     flatted "^3.1.0"
@@ -478,31 +478,31 @@ flat-cache@^3.0.4:
 
 flatted@^3.1.0:
   version "3.2.7"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 glob-parent@^5.1.2:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
 glob-parent@^6.0.2:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
 
 glob@^7.1.3:
   version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
   dependencies:
     fs.realpath "^1.0.0"
@@ -514,14 +514,14 @@ glob@^7.1.3:
 
 globals@^13.19.0:
   version "13.19.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.19.0.tgz#7a42de8e6ad4f7242fbcca27ea5b23aca367b5c8"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz"
   integrity sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==
   dependencies:
     type-fest "^0.20.2"
 
 globby@^11.1.0:
   version "11.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
   dependencies:
     array-union "^2.1.0"
@@ -533,22 +533,22 @@ globby@^11.1.0:
 
 grapheme-splitter@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  resolved "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 has-flag@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 ignore@^5.2.0:
   version "5.2.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
@@ -556,12 +556,12 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
 
 imurmurhash@^0.1.4:
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
 inflight@^1.0.4:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
   integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
   dependencies:
     once "^1.3.0"
@@ -569,61 +569,61 @@ inflight@^1.0.4:
 
 inherits@2:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 is-extglob@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-path-inside@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 isexe@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 js-sdsl@^4.1.4:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.2.0.tgz#278e98b7bea589b8baaf048c20aeb19eb7ad09d0"
+  resolved "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz"
   integrity sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==
 
 js-yaml@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
 levn@^0.4.1:
   version "0.4.1"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
   integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
   dependencies:
     prelude-ls "^1.2.1"
@@ -631,31 +631,31 @@ levn@^0.4.1:
 
 locate-path@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
 
 lodash.merge@^4.6.2:
   version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lru-cache@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz"
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 micromatch@^4.0.4:
   version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
     braces "^3.0.2"
@@ -663,36 +663,36 @@ micromatch@^4.0.4:
 
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
 ms@2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  resolved "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz"
   integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 once@^1.3.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
 optionator@^0.9.1:
   version "0.9.1"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz"
   integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
   dependencies:
     deep-is "^0.1.3"
@@ -704,193 +704,198 @@ optionator@^0.9.1:
 
 p-limit@^3.0.2:
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
 
 p-locate@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
 
 parent-module@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
 
 path-exists@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-type@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 picomatch@^2.3.1:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 prelude-ls@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz"
+  integrity sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==
 
 punycode@^2.1.0:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 regexpp@^3.2.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
 resolve-from@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 reusify@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
 rimraf@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
 run-parallel@^1.1.9:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
 
 semver@^7.3.5, semver@^7.3.7:
   version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
 
 shebang-regex@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 slash@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 strip-ansi@^6.0.1:
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
 
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 supports-color@^7.1.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
 text-table@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
 
 tslib@^1.8.1:
   version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tsutils@^3.21.0:
   version "3.21.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
 
 type-fest@^0.20.2:
   version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@^4.7.4:
+typescript@^4.7.4, "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta":
   version "4.9.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz"
   integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 uri-js@^4.2.2:
   version "4.4.1"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
 vscode-jsonrpc@8.0.2:
   version "8.0.2"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz"
   integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
 
 vscode-languageclient@^8.0.2:
   version "8.0.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz#f1f23ce8c8484aa11e4b7dfb24437d3e59bb61c6"
+  resolved "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz"
   integrity sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==
   dependencies:
     minimatch "^3.0.4"
@@ -899,7 +904,7 @@ vscode-languageclient@^8.0.2:
 
 vscode-languageserver-protocol@3.17.2:
   version "3.17.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  resolved "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz"
   integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
   dependencies:
     vscode-jsonrpc "8.0.2"
@@ -907,44 +912,44 @@ vscode-languageserver-protocol@3.17.2:
 
 vscode-languageserver-textdocument@^1.0.5:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz#9eae94509cbd945ea44bca8dcfe4bb0c15bb3ac0"
+  resolved "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz"
   integrity sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==
 
 vscode-languageserver-types@3.17.2:
   version "3.17.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz"
   integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
 
 vscode-languageserver@^8.0.2:
   version "8.0.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz#cfe2f0996d9dfd40d3854e786b2821604dfec06d"
+  resolved "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz"
   integrity sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==
   dependencies:
     vscode-languageserver-protocol "3.17.2"
 
 which@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
 word-wrap@^1.2.3:
   version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wrappy@1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 yallist@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yocto-queue@^0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
This PR is open for testing the new dialog and menu preview functionality.

I don't fully remember the remaining loose ends, but the feature should be close to production ready. It may still need some polishing and edge case fixes, so feedback from real world projects would be appreciated.

A `.vsix` build is here ( https://files.catbox.moe/2qcvlj.vsix ) so anyone interested can install it locally and report issues. If afraid, just build it from source.

In addition to native `ShowPlayerDialog` wrappers, the preview currently supports:

* `samp-async-dialogs`
* `tdialogs`
* `easyDialog`
* `y_dialog`
* `mdialog`
* `pp_dialogs`
* `tdw_dialog`

Some dynamic cases are still handled on a best effort basis. The preview does not fully execute Pawn code, some content may not render exactly as they do in-game.
